### PR TITLE
Full UX redesign of all 5 webview panels

### DIFF
--- a/webview-ui/src/lib/CopyButton.svelte
+++ b/webview-ui/src/lib/CopyButton.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  interface Props {
+    text: string;
+    label?: string;
+  }
+
+  let { text, label = "Copy" }: Props = $props();
+  let copied = $state(false);
+
+  async function copy() {
+    await navigator.clipboard.writeText(text);
+    copied = true;
+    setTimeout(() => { copied = false; }, 2000);
+  }
+</script>
+
+<button class="copy-btn icon-btn" onclick={copy} title={label}>
+  {#if copied}
+    <span class="check">&#10003;</span>
+  {:else}
+    <span class="icon">&#128203;</span>
+  {/if}
+</button>
+
+<style>
+  .copy-btn { font-size: 0.85em; }
+  .check { color: var(--vscode-testing-iconPassed, #73c991); }
+</style>

--- a/webview-ui/src/lib/EmptyState.svelte
+++ b/webview-ui/src/lib/EmptyState.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    state: "loading" | "empty" | "error";
+    message: string;
+    action?: Snippet;
+  }
+
+  let { state, message, action }: Props = $props();
+
+  const icons: Record<string, string> = {
+    loading: "&#8987;",
+    empty: "&#128193;",
+    error: "&#9888;",
+  };
+</script>
+
+<div class="empty-state">
+  <span class="icon">{@html icons[state]}</span>
+  <p>{message}</p>
+  {#if action}
+    {@render action()}
+  {/if}
+</div>

--- a/webview-ui/src/lib/JsonViewer.svelte
+++ b/webview-ui/src/lib/JsonViewer.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  interface Props {
+    data: unknown;
+    expanded?: boolean;
+    depth?: number;
+    maxDepth?: number;
+  }
+
+  let { data, expanded = true, depth = 0, maxDepth = 6 }: Props = $props();
+  let isExpanded = $state(expanded && depth < 2);
+
+  let isObject = $derived(data !== null && typeof data === "object" && !Array.isArray(data));
+  let isArray = $derived(Array.isArray(data));
+  let entries = $derived(
+    isObject ? Object.entries(data as Record<string, unknown>) :
+    isArray ? (data as unknown[]).map((v, i) => [String(i), v] as [string, unknown]) :
+    []
+  );
+  let preview = $derived(
+    isObject ? `{${entries.length}}` :
+    isArray ? `[${entries.length}]` :
+    ""
+  );
+
+  function toggle() { isExpanded = !isExpanded; }
+
+  function typeClass(val: unknown): string {
+    if (val === null) return "null";
+    if (typeof val === "string") return "string";
+    if (typeof val === "number") return "number";
+    if (typeof val === "boolean") return "boolean";
+    return "";
+  }
+
+  function formatValue(val: unknown): string {
+    if (val === null) return "null";
+    if (typeof val === "string") return `"${val}"`;
+    return String(val);
+  }
+</script>
+
+{#if isObject || isArray}
+  {#if depth < maxDepth}
+    <span class="toggle" onclick={toggle} role="button" tabindex="0" onkeydown={(e) => e.key === "Enter" && toggle()}>
+      <span class="arrow" class:open={isExpanded}>&#9656;</span>
+      <span class="preview">{isArray ? "Array" : "Object"} {preview}</span>
+    </span>
+    {#if isExpanded}
+      <div class="entries" style="padding-left: {depth > 0 ? 16 : 0}px">
+        {#each entries as [key, val]}
+          <div class="entry">
+            <span class="key">{key}:</span>
+            {#if val !== null && typeof val === "object"}
+              <svelte:self data={val} depth={depth + 1} {maxDepth} />
+            {:else}
+              <span class="value {typeClass(val)}">{formatValue(val)}</span>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {:else}
+    <span class="preview">{JSON.stringify(data)}</span>
+  {/if}
+{:else}
+  <span class="value {typeClass(data)}">{formatValue(data)}</span>
+{/if}
+
+<style>
+  .toggle { cursor: pointer; user-select: none; display: inline-flex; align-items: center; gap: 4px; }
+  .arrow { display: inline-block; transition: transform 0.15s; font-size: 0.8em; }
+  .arrow.open { transform: rotate(90deg); }
+  .preview { color: var(--vscode-descriptionForeground); font-size: 0.9em; }
+  .entries { border-left: 1px solid var(--vscode-widget-border, rgba(128,128,128,0.2)); margin-left: 4px; }
+  .entry { padding: 1px 0; font-family: var(--vscode-editor-font-family); font-size: var(--vscode-editor-font-size); }
+  .key { color: var(--vscode-symbolIcon-propertyForeground, #9cdcfe); margin-right: 4px; }
+  .value.string { color: var(--vscode-debugTokenExpression-string, #ce9178); }
+  .value.number { color: var(--vscode-debugTokenExpression-number, #b5cea8); }
+  .value.boolean { color: var(--vscode-debugTokenExpression-boolean, #569cd6); }
+  .value.null { color: var(--vscode-descriptionForeground); font-style: italic; }
+</style>

--- a/webview-ui/src/lib/KeyValue.svelte
+++ b/webview-ui/src/lib/KeyValue.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import CopyButton from "./CopyButton.svelte";
+
+  interface Props {
+    label: string;
+    value: string;
+    mono?: boolean;
+    copyable?: boolean;
+  }
+
+  let { label, value, mono = false, copyable = false }: Props = $props();
+</script>
+
+<div class="kv-row">
+  <dt class="kv-label">{label}</dt>
+  <dd class="kv-value" class:mono>
+    {value}
+    {#if copyable}
+      <CopyButton text={value} />
+    {/if}
+  </dd>
+</div>
+
+<style>
+  .kv-row { display: flex; align-items: baseline; gap: var(--space-2, 8px); padding: 3px 0; }
+  .kv-label { color: var(--vscode-descriptionForeground); font-size: 0.85em; min-width: 90px; flex-shrink: 0; }
+  .kv-value { display: flex; align-items: center; gap: 4px; word-break: break-all; }
+  .mono { font-family: var(--vscode-editor-font-family); font-size: var(--vscode-editor-font-size); }
+</style>

--- a/webview-ui/src/lib/Sparkline.svelte
+++ b/webview-ui/src/lib/Sparkline.svelte
@@ -1,31 +1,47 @@
 <script lang="ts">
-  let {
-    values,
-    width = 100,
-    height = 20,
-    color = "var(--vscode-charts-blue)",
-  }: {
+  interface Props {
     values: number[];
     width?: number;
     height?: number;
     color?: string;
-  } = $props();
+    showValue?: boolean;
+    fill?: boolean;
+  }
+
+  let { values, width = 120, height = 28, color = "var(--vscode-charts-blue, #3794ff)", showValue = false, fill = true }: Props = $props();
 
   let points = $derived.by(() => {
-    if (values.length === 0) return "";
-    const max = Math.max(...values, 1);
-    const min = Math.min(...values, 0);
+    if (values.length < 2) return "";
+    const max = Math.max(...values);
+    const min = Math.min(...values);
     const range = max - min || 1;
-    return values
-      .map((v, i) => {
-        const x = (i / Math.max(values.length - 1, 1)) * width;
-        const y = height - ((v - min) / range) * (height - 2) - 1;
-        return `${x},${y}`;
-      })
-      .join(" ");
+    const stepX = width / (values.length - 1);
+    return values.map((v, i) => `${i * stepX},${height - ((v - min) / range) * (height - 4) - 2}`).join(" ");
   });
+
+  let fillPoints = $derived(
+    points ? `0,${height} ${points} ${width},${height}` : ""
+  );
+
+  let lastValue = $derived(values.length > 0 ? values[values.length - 1] : 0);
 </script>
 
-<svg {width} {height}>
-  <polyline {points} fill="none" stroke={color} stroke-width="1.5" />
-</svg>
+<span class="sparkline-wrap">
+  <svg viewBox="0 0 {width} {height}" preserveAspectRatio="none" class="sparkline">
+    {#if fill && fillPoints}
+      <polygon points={fillPoints} fill={color} opacity="0.15" />
+    {/if}
+    {#if points}
+      <polyline points={points} fill="none" stroke={color} stroke-width="1.5" stroke-linejoin="round" />
+    {/if}
+  </svg>
+  {#if showValue && values.length > 0}
+    <span class="spark-value" style="color: {color}">{typeof lastValue === 'number' && lastValue > 1000 ? (lastValue / 1000).toFixed(1) + 'K' : lastValue}</span>
+  {/if}
+</span>
+
+<style>
+  .sparkline-wrap { display: inline-flex; align-items: center; gap: 6px; }
+  .sparkline { width: 100%; max-width: 120px; height: 28px; }
+  .spark-value { font-size: 0.8em; font-variant-numeric: tabular-nums; white-space: nowrap; }
+</style>

--- a/webview-ui/src/lib/StatusBadge.svelte
+++ b/webview-ui/src/lib/StatusBadge.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  interface Props {
+    status: "success" | "warning" | "error" | "info";
+    label: string;
+  }
+
+  let { status, label }: Props = $props();
+</script>
+
+<span class="badge {status}">{label}</span>

--- a/webview-ui/src/lib/VirtualList.svelte
+++ b/webview-ui/src/lib/VirtualList.svelte
@@ -5,9 +5,10 @@
     items: unknown[];
     itemHeight: number;
     children: Snippet<[{ item: unknown; index: number }]>;
+    totalLabel?: string;
   }
 
-  let { items, itemHeight, children }: Props = $props();
+  let { items, itemHeight, children, totalLabel }: Props = $props();
 
   let container: HTMLDivElement | undefined = $state();
   let scrollTop = $state(0);
@@ -48,6 +49,9 @@
     </div>
   </div>
 </div>
+{#if totalLabel && items.length > 0}
+  <div class="vl-count">{items.length} {totalLabel}</div>
+{/if}
 
 <style>
   .virtual-list {
@@ -67,4 +71,5 @@
   .virtual-list-item {
     overflow: hidden;
   }
+  .vl-count { padding: 4px 8px; font-size: 0.8em; color: var(--vscode-descriptionForeground); text-align: right; flex-shrink: 0; }
 </style>

--- a/webview-ui/src/lib/theme.css
+++ b/webview-ui/src/lib/theme.css
@@ -19,10 +19,15 @@ button {
   background: var(--vscode-button-background);
   color: var(--vscode-button-foreground);
   border: none;
-  padding: 4px 12px;
+  min-height: 28px;
+  padding: 5px 14px;
+  border-radius: var(--radius);
   cursor: pointer;
   font-family: inherit;
   font-size: inherit;
+  font-weight: 500;
+  transition: background-color 0.1s, opacity 0.1s;
+  user-select: none;
 }
 
 button:hover {
@@ -110,4 +115,170 @@ pre {
   overflow: auto;
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+/* Spacing scale */
+:root {
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --radius: 4px;
+  --radius-lg: 6px;
+}
+
+button:active {
+  opacity: 0.8;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.small {
+  min-height: 22px;
+  padding: 2px 8px;
+  font-size: 0.85em;
+}
+
+button.icon-btn {
+  min-height: 22px;
+  padding: 2px 6px;
+  background: none;
+  color: var(--vscode-foreground);
+  opacity: 0.7;
+}
+
+button.icon-btn:hover {
+  opacity: 1;
+  background: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+}
+
+button.danger {
+  background: var(--vscode-inputValidation-errorBackground, #5a1d1d);
+  color: var(--vscode-errorForeground, #f48771);
+}
+
+/* Utility classes */
+.mono {
+  font-family: var(--vscode-editor-font-family);
+  font-size: var(--vscode-editor-font-size);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+  flex-shrink: 0;
+}
+
+.panel-section {
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 0.8em;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.badge.info {
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+
+.badge.success {
+  background: rgba(40, 167, 69, 0.2);
+  color: var(--vscode-testing-iconPassed, #73c991);
+}
+
+.badge.warning {
+  background: rgba(204, 167, 0, 0.2);
+  color: var(--vscode-charts-yellow, #cca700);
+}
+
+.badge.error {
+  background: rgba(244, 135, 113, 0.15);
+  color: var(--vscode-testing-iconFailed, #f48771);
+}
+
+.tabs {
+  display: flex;
+  border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+  flex-shrink: 0;
+}
+
+.tabs button {
+  flex: 1;
+  min-height: auto;
+  padding: var(--space-2) var(--space-3);
+  background: none;
+  color: var(--vscode-foreground);
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+  opacity: 0.7;
+}
+
+.tabs button:hover {
+  opacity: 1;
+  background: none;
+}
+
+.tabs button.active {
+  border-bottom-color: var(--vscode-focusBorder);
+  color: var(--vscode-focusBorder);
+  opacity: 1;
+}
+
+.split-pane {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.split-left {
+  width: 30%;
+  min-width: 200px;
+  max-width: 400px;
+  border-right: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.split-right {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-8);
+  color: var(--vscode-descriptionForeground);
+  text-align: center;
+  gap: var(--space-3);
+}
+
+.empty-state .icon {
+  font-size: 2em;
+  opacity: 0.5;
 }

--- a/webview-ui/src/panels/kv-editor/App.svelte
+++ b/webview-ui/src/panels/kv-editor/App.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
   import { vscode } from "../../lib/vscode-api";
+  import JsonViewer from "../../lib/JsonViewer.svelte";
+  import CopyButton from "../../lib/CopyButton.svelte";
+  import StatusBadge from "../../lib/StatusBadge.svelte";
+  import EmptyState from "../../lib/EmptyState.svelte";
+  import KeyValue from "../../lib/KeyValue.svelte";
+  import VirtualList from "../../lib/VirtualList.svelte";
 
   interface KvEntry {
     key: string;
@@ -12,15 +18,35 @@
 
   let connectionId = $state("");
   let bucket = $state("");
-  let key = $state("");
+  let keys = $state<string[]>([]);
+  let selectedKey = $state<string | null>(null);
   let entry = $state<KvEntry | null>(null);
   let editMode = $state(false);
   let editValue = $state("");
   let historyEntries = $state<KvEntry[]>([]);
   let showHistory = $state(false);
-  let loading = $state(true);
   let watching = $state(false);
   let watchId = $state("");
+  let keyFilter = $state("");
+  let loading = $state(true);
+  let loadingEntry = $state(false);
+  let creatingKey = $state(false);
+  let newKeyName = $state("");
+
+  let filteredKeys = $derived(
+    keyFilter
+      ? keys.filter((k) => k.toLowerCase().includes(keyFilter.toLowerCase()))
+      : keys
+  );
+
+  let parsedJson = $derived.by(() => {
+    if (!entry || entry.valueEncoding === "base64") return null;
+    try {
+      return JSON.parse(entry.value);
+    } catch {
+      return null;
+    }
+  });
 
   $effect(() => {
     const handler = (event: MessageEvent) => {
@@ -28,16 +54,23 @@
       if (msg.type === "init") {
         connectionId = msg.connectionId;
         bucket = msg.bucket;
-        key = msg.key;
-        fetchEntry();
-        if (msg.showHistory) fetchHistory();
+        if (msg.key) {
+          selectedKey = msg.key;
+        }
+        fetchKeys();
+        if (msg.showHistory) showHistory = true;
+      } else if (msg.type === "kv:keys:data") {
+        keys = msg.keys;
+        loading = false;
+        if (selectedKey) {
+          fetchEntry(selectedKey);
+        }
       } else if (msg.type === "kv:entry") {
         entry = msg.entry;
         editValue = msg.entry.value;
-        loading = false;
+        loadingEntry = false;
       } else if (msg.type === "kv:history:data") {
         historyEntries = msg.entries;
-        showHistory = true;
       } else if (msg.type === "kv:watch:update") {
         if (msg.id === watchId) {
           entry = msg.entry;
@@ -45,140 +78,525 @@
         }
       } else if (msg.type === "error") {
         loading = false;
+        loadingEntry = false;
       }
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
   });
 
-  function fetchEntry() {
+  function fetchKeys() {
     loading = true;
+    vscode.postMessage({ type: "kv:keys", connectionId, bucket });
+  }
+
+  function fetchEntry(key: string) {
+    loadingEntry = true;
+    showHistory = false;
+    historyEntries = [];
     vscode.postMessage({ type: "kv:get", connectionId, bucket, key });
+  }
+
+  function selectKey(key: string) {
+    if (watching) stopWatch();
+    editMode = false;
+    selectedKey = key;
+    fetchEntry(key);
   }
 
   function fetchHistory() {
     showHistory = !showHistory;
-    if (showHistory) {
-      vscode.postMessage({ type: "kv:history", connectionId, bucket, key });
+    if (showHistory && selectedKey) {
+      vscode.postMessage({
+        type: "kv:history",
+        connectionId,
+        bucket,
+        key: selectedKey,
+      });
     }
   }
 
   function toggleWatch() {
     if (watching) {
-      vscode.postMessage({ type: "kv:unwatch", id: watchId });
-      watching = false;
-      watchId = "";
-    } else {
+      stopWatch();
+    } else if (selectedKey) {
       const id = `watch-${Date.now()}`;
       watchId = id;
-      vscode.postMessage({ type: "kv:watch", connectionId, bucket, key, id });
+      vscode.postMessage({
+        type: "kv:watch",
+        connectionId,
+        bucket,
+        key: selectedKey,
+        id,
+      });
       watching = true;
     }
   }
 
-  function startEdit() { editMode = true; editValue = entry?.value ?? ""; }
-  function cancelEdit() { editMode = false; editValue = entry?.value ?? ""; }
+  function stopWatch() {
+    vscode.postMessage({ type: "kv:unwatch", id: watchId });
+    watching = false;
+    watchId = "";
+  }
+
+  function startEdit() {
+    editMode = true;
+    editValue = entry?.value ?? "";
+  }
+  function cancelEdit() {
+    editMode = false;
+    editValue = entry?.value ?? "";
+  }
   function saveEdit() {
-    vscode.postMessage({ type: "kv:put", connectionId, bucket, key, value: editValue });
+    if (!selectedKey) return;
+    vscode.postMessage({
+      type: "kv:put",
+      connectionId,
+      bucket,
+      key: selectedKey,
+      value: editValue,
+    });
     editMode = false;
   }
 
-  function formatValue(val: string, encoding: string): string {
-    if (encoding === "base64") return `[base64] ${val}`;
-    try { return JSON.stringify(JSON.parse(val), null, 2); }
-    catch { return val; }
+  function startCreateKey() {
+    creatingKey = true;
+    newKeyName = "";
+  }
+
+  function cancelCreateKey() {
+    creatingKey = false;
+    newKeyName = "";
+  }
+
+  function submitCreateKey() {
+    if (!newKeyName.trim()) return;
+    vscode.postMessage({
+      type: "kv:put",
+      connectionId,
+      bucket,
+      key: newKeyName.trim(),
+      value: "",
+    });
+    selectedKey = newKeyName.trim();
+    creatingKey = false;
+    newKeyName = "";
+    // Refresh keys list after a short delay
+    setTimeout(fetchKeys, 300);
   }
 
   function formatTimestamp(ts: string): string {
-    return ts.replace("T", " ").replace("Z", "");
+    if (!ts) return "-";
+    return ts.replace("T", " ").replace("Z", " UTC");
+  }
+
+  function operationBadgeStatus(
+    op: string
+  ): "success" | "warning" | "error" | "info" {
+    if (op === "PUT") return "success";
+    if (op === "DEL" || op === "PURGE") return "error";
+    return "info";
   }
 </script>
 
 <main>
-  <div class="header">
-    <div class="breadcrumb">
-      <span class="bucket-name">{bucket}</span>
-      <span class="sep">/</span>
-      <span class="key-name">{key}</span>
-      {#if watching}
-        <span class="live-badge">LIVE</span>
-      {/if}
-    </div>
-    {#if entry}
-      <div class="meta">
-        <span>Rev {entry.revision}</span>
-        <span class="sep">|</span>
-        <span>{entry.operation}</span>
-        <span class="sep">|</span>
-        <span>{formatTimestamp(entry.created)}</span>
-      </div>
-    {/if}
-  </div>
-
   {#if loading}
-    <div class="loading">Loading...</div>
-  {:else if !entry}
-    <div class="empty">Key not found.</div>
+    <EmptyState state="loading" message="Loading keys..." />
   {:else}
-    <div class="toolbar">
-      {#if editMode}
-        <button onclick={saveEdit}>Save</button>
-        <button class="secondary" onclick={cancelEdit}>Cancel</button>
-      {:else}
-        <button onclick={startEdit}>Edit</button>
-      {/if}
-      <button class="secondary" onclick={toggleWatch}>{watching ? "Stop Watch" : "Watch"}</button>
-      <button class="secondary" onclick={fetchHistory}>{showHistory ? "Hide History" : "Show History"}</button>
-      <button class="secondary" onclick={fetchEntry}>Refresh</button>
-    </div>
+    <div class="split-pane">
+      <!-- Left pane: key list -->
+      <div class="split-left">
+        <div class="list-header">
+          <div class="list-title">
+            <span class="bucket-name">{bucket}</span>
+            <span class="badge info">{filteredKeys.length}</span>
+          </div>
+          <button class="small" onclick={startCreateKey}>+ New Key</button>
+        </div>
 
-    <div class="value-pane">
-      {#if editMode}
-        <textarea bind:value={editValue} rows={20} class="value-editor"></textarea>
-      {:else}
-        <pre class="value-display">{formatValue(entry.value, entry.valueEncoding)}</pre>
-      {/if}
-    </div>
+        {#if creatingKey}
+          <div class="create-key-row">
+            <input
+              type="text"
+              bind:value={newKeyName}
+              placeholder="Key name..."
+              onkeydown={(e) => {
+                if (e.key === "Enter") submitCreateKey();
+                if (e.key === "Escape") cancelCreateKey();
+              }}
+            />
+            <button class="small" onclick={submitCreateKey}>Add</button>
+            <button class="small secondary" onclick={cancelCreateKey}
+              >Cancel</button
+            >
+          </div>
+        {/if}
 
-    {#if showHistory}
-      <div class="history-pane">
-        <h4>History</h4>
-        <table>
-          <thead>
-            <tr><th>Rev</th><th>Operation</th><th>Created</th><th>Value</th></tr>
-          </thead>
-          <tbody>
-            {#each historyEntries as he}
-              <tr>
-                <td>{he.revision}</td>
-                <td>{he.operation}</td>
-                <td class="mono">{formatTimestamp(he.created)}</td>
-                <td class="value-preview">{he.value.slice(0, 80)}{he.value.length > 80 ? "..." : ""}</td>
-              </tr>
-            {/each}
-          </tbody>
-        </table>
+        <div class="search-row">
+          <input
+            type="text"
+            bind:value={keyFilter}
+            placeholder="Filter keys..."
+            class="search-input"
+          />
+        </div>
+
+        <VirtualList items={filteredKeys} itemHeight={32} totalLabel="keys">
+          {#snippet children({ item, index })}
+            {@const k = item as string}
+            <button
+              class="key-row"
+              class:selected={k === selectedKey}
+              onclick={() => selectKey(k)}
+            >
+              <span class="key-name mono">{k}</span>
+            </button>
+          {/snippet}
+        </VirtualList>
       </div>
-    {/if}
+
+      <!-- Right pane: value viewer/editor -->
+      <div class="split-right">
+        {#if !selectedKey}
+          <EmptyState state="empty" message="Select a key to view its value" />
+        {:else if loadingEntry}
+          <EmptyState state="loading" message="Loading entry..." />
+        {:else if !entry}
+          <EmptyState state="error" message="Key not found" />
+        {:else}
+          <!-- Entry header -->
+          <div class="entry-header">
+            <div class="entry-title-row">
+              <span class="entry-key mono">{entry.key}</span>
+              <CopyButton text={entry.key} label="Copy key name" />
+              {#if watching}
+                <StatusBadge status="success" label="LIVE" />
+              {/if}
+            </div>
+            <div class="entry-meta">
+              <span class="badge info">r{entry.revision}</span>
+              <StatusBadge
+                status={operationBadgeStatus(entry.operation)}
+                label={entry.operation}
+              />
+              <span class="timestamp">{formatTimestamp(entry.created)}</span>
+            </div>
+          </div>
+
+          <!-- Actions toolbar -->
+          <div class="toolbar">
+            {#if editMode}
+              <button onclick={saveEdit}>Save</button>
+              <button class="secondary" onclick={cancelEdit}>Cancel</button>
+            {:else}
+              <button onclick={startEdit}>Edit</button>
+            {/if}
+            <button class="secondary" onclick={toggleWatch}>
+              {watching ? "Stop Watch" : "Watch"}
+            </button>
+            <button class="secondary" onclick={fetchHistory}>
+              {showHistory ? "Hide History" : "History"}
+            </button>
+            <div class="spacer"></div>
+            <button
+              class="secondary"
+              onclick={() => selectedKey && fetchEntry(selectedKey)}>Refresh</button
+            >
+          </div>
+
+          <!-- Value display -->
+          <div class="value-pane">
+            {#if editMode}
+              <textarea
+                bind:value={editValue}
+                class="value-editor"
+                spellcheck="false"
+              ></textarea>
+            {:else}
+              <div class="value-content">
+                {#if entry.valueEncoding === "base64"}
+                  <div class="base64-notice">
+                    <StatusBadge status="info" label="base64" />
+                    <pre class="mono">{entry.value}</pre>
+                  </div>
+                {:else if parsedJson !== null}
+                  <div class="json-viewer-wrap">
+                    <div class="value-actions">
+                      <CopyButton text={entry.value} label="Copy value" />
+                    </div>
+                    <JsonViewer data={parsedJson} />
+                  </div>
+                {:else}
+                  <div class="text-value-wrap">
+                    <div class="value-actions">
+                      <CopyButton text={entry.value} label="Copy value" />
+                    </div>
+                    <pre>{entry.value}</pre>
+                  </div>
+                {/if}
+              </div>
+            {/if}
+          </div>
+
+          <!-- History section -->
+          {#if showHistory}
+            <div class="history-pane">
+              <div class="history-header">
+                <span class="history-title">History</span>
+                <span class="badge info">{historyEntries.length}</span>
+              </div>
+              {#if historyEntries.length === 0}
+                <div class="history-empty">Loading history...</div>
+              {:else}
+                <div class="history-list">
+                  {#each historyEntries as he}
+                    <div class="history-entry">
+                      <div class="history-entry-header">
+                        <span class="badge info">r{he.revision}</span>
+                        <StatusBadge
+                          status={operationBadgeStatus(he.operation)}
+                          label={he.operation}
+                        />
+                        <span class="timestamp"
+                          >{formatTimestamp(he.created)}</span
+                        >
+                      </div>
+                      <div class="history-value mono">
+                        {he.value.slice(0, 120)}{he.value.length > 120
+                          ? "..."
+                          : ""}
+                      </div>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          {/if}
+        {/if}
+      </div>
+    </div>
   {/if}
 </main>
 
 <style>
-  main { display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
-  .header { padding: 8px; border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); flex-shrink: 0; }
-  .breadcrumb { font-weight: 600; font-size: 1.1em; display: flex; align-items: center; gap: 4px; }
-  .bucket-name { color: var(--vscode-descriptionForeground); }
-  .sep { color: var(--vscode-descriptionForeground); margin: 0 4px; }
-  .live-badge { background: #27ae60; color: white; font-size: 0.7em; padding: 1px 6px; border-radius: 8px; margin-left: 8px; animation: pulse 2s infinite; }
-  @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
-  .meta { font-size: 0.85em; color: var(--vscode-descriptionForeground); margin-top: 4px; }
-  .toolbar { display: flex; gap: 4px; padding: 8px; flex-shrink: 0; }
-  .value-pane { flex: 1; overflow: auto; padding: 0 8px; min-height: 100px; }
-  .value-display { margin: 0; white-space: pre-wrap; word-break: break-all; }
-  .value-editor { width: 100%; font-family: var(--vscode-editor-font-family); font-size: var(--vscode-editor-font-size); resize: vertical; }
-  .history-pane { border-top: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); max-height: 35vh; overflow: auto; padding: 8px; flex-shrink: 0; }
-  .history-pane h4 { margin: 0 0 8px 0; color: var(--vscode-descriptionForeground); }
-  .mono { font-family: var(--vscode-editor-font-family); font-size: var(--vscode-editor-font-size); }
-  .value-preview { font-family: var(--vscode-editor-font-family); font-size: var(--vscode-editor-font-size); max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .loading, .empty { padding: 24px; text-align: center; color: var(--vscode-descriptionForeground); }
+  main {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  /* Left pane */
+  .list-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-2);
+    border-bottom: 1px solid
+      var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+    flex-shrink: 0;
+  }
+
+  .list-title {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-weight: 600;
+  }
+
+  .bucket-name {
+    font-size: 0.95em;
+  }
+
+  .search-row {
+    padding: var(--space-1) var(--space-2);
+    flex-shrink: 0;
+  }
+
+  .search-input {
+    width: 100%;
+    border-radius: var(--radius);
+  }
+
+  .create-key-row {
+    display: flex;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-2);
+    flex-shrink: 0;
+  }
+
+  .create-key-row input {
+    flex: 1;
+    min-width: 0;
+    border-radius: var(--radius);
+  }
+
+  .key-row {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 0 var(--space-2);
+    height: 32px;
+    background: none;
+    border: none;
+    border-radius: 0;
+    color: var(--vscode-foreground);
+    cursor: pointer;
+    text-align: left;
+    min-height: 32px;
+    gap: var(--space-2);
+  }
+
+  .key-row:hover {
+    background: var(--vscode-list-hoverBackground);
+  }
+
+  .key-row.selected {
+    background: var(--vscode-list-activeSelectionBackground);
+    color: var(--vscode-list-activeSelectionForeground);
+  }
+
+  .key-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    font-size: 0.9em;
+  }
+
+  /* Right pane */
+  .entry-header {
+    padding: var(--space-3);
+    border-bottom: 1px solid
+      var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+    flex-shrink: 0;
+  }
+
+  .entry-title-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-1);
+  }
+
+  .entry-key {
+    font-weight: 600;
+    font-size: 1.1em;
+  }
+
+  .entry-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .timestamp {
+    font-size: 0.85em;
+    color: var(--vscode-descriptionForeground);
+  }
+
+  .spacer {
+    flex: 1;
+  }
+
+  .value-pane {
+    flex: 1;
+    overflow: auto;
+    min-height: 0;
+  }
+
+  .value-content {
+    padding: var(--space-3);
+  }
+
+  .value-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: var(--space-1);
+  }
+
+  .json-viewer-wrap,
+  .text-value-wrap {
+    position: relative;
+  }
+
+  .base64-notice {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .value-editor {
+    width: 100%;
+    height: 100%;
+    min-height: 200px;
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size);
+    resize: none;
+    border: none;
+    border-radius: 0;
+    padding: var(--space-3);
+  }
+
+  /* History pane */
+  .history-pane {
+    border-top: 1px solid
+      var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+    max-height: 35vh;
+    overflow: auto;
+    flex-shrink: 0;
+  }
+
+  .history-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    position: sticky;
+    top: 0;
+    background: var(--vscode-editor-background);
+    border-bottom: 1px solid
+      var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+  }
+
+  .history-title {
+    font-weight: 600;
+    font-size: 0.9em;
+  }
+
+  .history-empty {
+    padding: var(--space-3);
+    color: var(--vscode-descriptionForeground);
+    text-align: center;
+    font-size: 0.9em;
+  }
+
+  .history-list {
+    padding: var(--space-1) 0;
+  }
+
+  .history-entry {
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid
+      var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+  }
+
+  .history-entry:last-child {
+    border-bottom: none;
+  }
+
+  .history-entry-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-1);
+  }
+
+  .history-value {
+    font-size: 0.85em;
+    color: var(--vscode-descriptionForeground);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 </style>

--- a/webview-ui/src/panels/message-browser/App.svelte
+++ b/webview-ui/src/panels/message-browser/App.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { vscode } from "../../lib/vscode-api";
   import VirtualList from "../../lib/VirtualList.svelte";
+  import JsonViewer from "../../lib/JsonViewer.svelte";
+  import CopyButton from "../../lib/CopyButton.svelte";
+  import KeyValue from "../../lib/KeyValue.svelte";
+  import EmptyState from "../../lib/EmptyState.svelte";
 
   interface NatsMessage {
     subject: string;
@@ -20,11 +24,25 @@
   let subjectFilter = $state("");
   let loading = $state(false);
   let jumpToSeq = $state("");
+  let detailOpen = $state(true);
+  let detailTab = $state<"payload" | "headers" | "info">("payload");
 
   // Time range mode
   let browseMode = $state<"sequence" | "time">("sequence");
   let startTime = $state("");
   let endTime = $state("");
+
+  // Bookmark state
+  let bookmarking = $state(false);
+  let bookmarkName = $state("");
+
+  // Derived
+  let messageCount = $derived(messages.length);
+  let parsedPayload = $derived.by(() => {
+    if (!selectedMessage) return null;
+    if (selectedMessage.payloadEncoding === "base64") return null;
+    try { return JSON.parse(selectedMessage.payload); } catch { return null; }
+  });
 
   $effect(() => {
     const handler = (event: MessageEvent) => {
@@ -69,6 +87,12 @@
       fetchMessages();
     }
   }
+  function goLast() {
+    // Go to last page - set high seq to get latest
+    startSeq = Number.MAX_SAFE_INTEGER;
+    browseMode = "sequence";
+    fetchMessages();
+  }
   function goJump() {
     const seq = parseInt(jumpToSeq);
     if (!isNaN(seq) && seq > 0) { startSeq = seq; browseMode = "sequence"; fetchMessages(); }
@@ -77,6 +101,7 @@
 
   function selectMessage(msg: NatsMessage) {
     selectedMessage = selectedMessage === msg ? null : msg;
+    if (selectedMessage) detailOpen = true;
   }
 
   function formatPayload(msg: NatsMessage): string {
@@ -91,11 +116,18 @@
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 
-  function copyToClipboard(text: string) { navigator.clipboard.writeText(text); }
+  function formatTimestamp(ts: string): string {
+    try {
+      const d = new Date(ts);
+      return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit", fractionalSecondDigits: 3 });
+    } catch { return ts; }
+  }
 
-  // Bookmark state
-  let bookmarking = $state(false);
-  let bookmarkName = $state("");
+  function formatFullTimestamp(ts: string): string {
+    try { return new Date(ts).toLocaleString(); } catch { return ts; }
+  }
+
+  function copyToClipboard(text: string) { navigator.clipboard.writeText(text); }
 
   function startBookmark() {
     bookmarking = true;
@@ -121,74 +153,89 @@
     bookmarking = false;
     bookmarkName = "";
   }
+
+  let hasHeaders = $derived(
+    selectedMessage?.headers != null && Object.keys(selectedMessage.headers).length > 0
+  );
 </script>
 
 <main>
+  <!-- Toolbar -->
   <div class="toolbar">
-    <span class="stream-name">{streamName || "No stream selected"}</span>
-    <div class="controls">
+    <div class="toolbar-left">
+      <span class="stream-title">{streamName || "No stream selected"}</span>
+      {#if messageCount > 0}
+        <span class="badge info">{messageCount.toLocaleString()} msgs</span>
+      {/if}
+    </div>
+    <div class="toolbar-right">
       <input type="text" bind:value={subjectFilter} placeholder="Filter by subject..."
         class="filter-input" onkeydown={(e) => e.key === "Enter" && fetchMessages()} />
-      <button onclick={goFirst} title="First">|&laquo;</button>
-      <button onclick={goPrev} title="Previous">&laquo;</button>
-      <button onclick={goNext} title="Next">&raquo;</button>
-      <input type="text" bind:value={jumpToSeq} placeholder="Seq #" class="jump-input"
-        onkeydown={(e) => e.key === "Enter" && goJump()} />
-      <button onclick={goJump}>Go</button>
-      <button onclick={fetchMessages} title="Refresh">&#x21bb;</button>
+      <div class="nav-group">
+        <button class="secondary small" onclick={goFirst} title="First page">|&laquo;</button>
+        <button class="secondary small" onclick={goPrev} title="Previous page">&laquo;</button>
+        <button class="secondary small" onclick={goNext} title="Next page">&raquo;</button>
+        <button class="secondary small" onclick={goLast} title="Last page">&raquo;|</button>
+      </div>
+      <div class="jump-group">
+        <input type="text" bind:value={jumpToSeq} placeholder="Seq #" class="jump-input"
+          onkeydown={(e) => e.key === "Enter" && goJump()} />
+        <button class="secondary small" onclick={goJump}>Go</button>
+      </div>
+      <button class="icon-btn" onclick={fetchMessages} title="Refresh">&#x21bb;</button>
     </div>
   </div>
 
+  <!-- Time range bar -->
   <div class="time-bar">
-    <label class="mode-toggle">
+    <label class="time-toggle">
       <input type="checkbox" checked={browseMode === "time"}
         onchange={() => browseMode = browseMode === "time" ? "sequence" : "time"} />
-      Time range
+      <span>Time range</span>
     </label>
     {#if browseMode === "time"}
-      <input type="datetime-local" bind:value={startTime} />
-      <span>to</span>
-      <input type="datetime-local" bind:value={endTime} />
-      <button class="secondary" onclick={fetchByTime}>Fetch</button>
+      <input type="datetime-local" bind:value={startTime} class="time-input" />
+      <span class="time-sep">to</span>
+      <input type="datetime-local" bind:value={endTime} class="time-input" />
+      <button class="secondary small" onclick={fetchByTime}>Fetch</button>
     {/if}
   </div>
 
+  <!-- Message list -->
   {#if loading}
-    <div class="loading">Loading messages...</div>
+    <EmptyState state="loading" message="Loading messages..." />
   {:else if messages.length === 0}
-    <div class="empty">No messages found.</div>
+    <EmptyState state="empty" message="No messages found." />
   {:else}
-    <div class="message-list-header">
-      <table>
-        <thead>
-          <tr>
-            <th class="col-seq">Seq</th>
-            <th class="col-subject">Subject</th>
-            <th class="col-ts">Timestamp</th>
-            <th class="col-size">Size</th>
-          </tr>
-        </thead>
-      </table>
+    <div class="list-header">
+      <span class="hdr-seq">Seq</span>
+      <span class="hdr-subject">Subject</span>
+      <span class="hdr-ts">Time</span>
+      <span class="hdr-size">Size</span>
     </div>
-    <VirtualList items={messages} itemHeight={32}>
+    <VirtualList items={messages} itemHeight={32} totalLabel="messages">
       {#snippet children({ item })}
         {@const msg = item as NatsMessage}
         <div class="msg-row" class:selected={selectedMessage === msg} onclick={() => selectMessage(msg)}>
           <span class="col-seq mono">{msg.sequence ?? "-"}</span>
           <span class="col-subject">{msg.subject}</span>
-          <span class="col-ts mono">{msg.timestamp}</span>
+          <span class="col-ts mono" title={msg.timestamp}>{formatTimestamp(msg.timestamp)}</span>
           <span class="col-size mono">{formatSize(msg.size)}</span>
         </div>
       {/snippet}
     </VirtualList>
   {/if}
 
-  {#if selectedMessage}
+  <!-- Detail pane -->
+  {#if selectedMessage && detailOpen}
     <div class="detail-pane">
-      <div class="detail-header">
-        <span>Seq {selectedMessage.sequence} &mdash; {selectedMessage.subject}</span>
+      <div class="detail-toolbar">
+        <div class="detail-tabs">
+          <button class="detail-tab" class:active={detailTab === "payload"} onclick={() => detailTab = "payload"}>Payload</button>
+          <button class="detail-tab" class:active={detailTab === "headers"} onclick={() => detailTab = "headers"}>Headers{#if hasHeaders} ({Object.keys(selectedMessage.headers!).length}){/if}</button>
+          <button class="detail-tab" class:active={detailTab === "info"} onclick={() => detailTab = "info"}>Info</button>
+        </div>
         <div class="detail-actions">
-          <button onclick={() => copyToClipboard(selectedMessage!.payload)}>Copy Payload</button>
           {#if bookmarking}
             <input
               type="text"
@@ -200,28 +247,50 @@
                 if (e.key === "Escape") cancelBookmark();
               }}
             />
-            <button onclick={confirmBookmark}>Save</button>
-            <button class="secondary" onclick={cancelBookmark}>Cancel</button>
+            <button class="small" onclick={confirmBookmark}>Save</button>
+            <button class="secondary small" onclick={cancelBookmark}>Cancel</button>
           {:else}
-            <button onclick={startBookmark}>Bookmark</button>
+            <button class="icon-btn" onclick={startBookmark} title="Bookmark this message">&#x2605;</button>
           {/if}
+          <button class="icon-btn" onclick={() => detailOpen = false} title="Close detail">&times;</button>
         </div>
       </div>
-      {#if selectedMessage.headers && Object.keys(selectedMessage.headers).length > 0}
-        <div class="section">
-          <h4>Headers</h4>
-          <table class="headers-table">
-            <tbody>
-              {#each Object.entries(selectedMessage.headers) as [key, values]}
-                <tr><td class="header-key">{key}</td><td>{values.join(", ")}</td></tr>
+
+      <div class="detail-content">
+        {#if detailTab === "payload"}
+          <div class="payload-header">
+            <CopyButton text={selectedMessage.payload} label="Copy payload" />
+          </div>
+          {#if selectedMessage.payloadEncoding === "base64"}
+            <pre class="payload-pre">[base64] {selectedMessage.payload}</pre>
+          {:else if parsedPayload !== null}
+            <div class="json-viewer-wrap">
+              <JsonViewer data={parsedPayload} />
+            </div>
+          {:else}
+            <pre class="payload-pre">{selectedMessage.payload}</pre>
+          {/if}
+
+        {:else if detailTab === "headers"}
+          {#if hasHeaders}
+            <div class="headers-list">
+              {#each Object.entries(selectedMessage.headers!) as [key, values]}
+                <KeyValue label={key} value={values.join(", ")} mono copyable />
               {/each}
-            </tbody>
-          </table>
-        </div>
-      {/if}
-      <div class="section">
-        <h4>Payload</h4>
-        <pre>{formatPayload(selectedMessage)}</pre>
+            </div>
+          {:else}
+            <EmptyState state="empty" message="No headers on this message." />
+          {/if}
+
+        {:else if detailTab === "info"}
+          <div class="info-list">
+            <KeyValue label="Subject" value={selectedMessage.subject} mono copyable />
+            <KeyValue label="Sequence" value={String(selectedMessage.sequence ?? "-")} mono />
+            <KeyValue label="Timestamp" value={formatFullTimestamp(selectedMessage.timestamp)} mono copyable />
+            <KeyValue label="Size" value={formatSize(selectedMessage.size)} mono />
+            <KeyValue label="Encoding" value={selectedMessage.payloadEncoding} mono />
+          </div>
+        {/if}
       </div>
     </div>
   {/if}
@@ -229,35 +298,58 @@
 
 <style>
   main { display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
-  .toolbar { display: flex; align-items: center; justify-content: space-between; padding: 6px 8px; gap: 8px; border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); flex-shrink: 0; }
-  .stream-name { font-weight: 600; white-space: nowrap; }
-  .controls { display: flex; gap: 4px; align-items: center; }
+
+  /* Toolbar */
+  .toolbar { display: flex; align-items: center; justify-content: space-between; padding: 6px 8px; gap: 8px; border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); flex-shrink: 0; flex-wrap: wrap; }
+  .toolbar-left { display: flex; align-items: center; gap: 8px; }
+  .stream-title { font-weight: 700; font-size: 1.05em; white-space: nowrap; }
+  .toolbar-right { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
   .filter-input { width: 180px; }
+  .nav-group { display: flex; gap: 2px; }
+  .nav-group button { min-width: 28px; padding: 2px 6px; }
+  .jump-group { display: flex; gap: 2px; }
   .jump-input { width: 70px; }
-  .time-bar { display: flex; gap: 8px; align-items: center; padding: 4px 8px; flex-shrink: 0; font-size: 0.9em; }
-  .mode-toggle { display: flex; align-items: center; gap: 4px; cursor: pointer; white-space: nowrap; }
-  .time-bar input[type="datetime-local"] { font-size: 0.9em; }
-  .loading, .empty { padding: 24px; text-align: center; color: var(--vscode-descriptionForeground); }
-  .message-list-header { flex-shrink: 0; }
-  .message-list-header table { margin-bottom: 0; }
-  .msg-row { display: flex; align-items: center; padding: 0 8px; cursor: pointer; height: 100%; }
+
+  /* Time bar */
+  .time-bar { display: flex; gap: 8px; align-items: center; padding: 4px 8px; flex-shrink: 0; font-size: 0.9em; border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); }
+  .time-toggle { display: flex; align-items: center; gap: 6px; cursor: pointer; white-space: nowrap; user-select: none; }
+  .time-input { font-size: 0.9em; }
+  .time-sep { color: var(--vscode-descriptionForeground); }
+
+  /* List header */
+  .list-header { display: flex; align-items: center; padding: 4px 8px; font-size: 0.8em; font-weight: 600; color: var(--vscode-descriptionForeground); text-transform: uppercase; letter-spacing: 0.03em; border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); flex-shrink: 0; }
+  .hdr-seq { width: 72px; flex-shrink: 0; }
+  .hdr-subject { flex: 1; }
+  .hdr-ts { width: 120px; flex-shrink: 0; }
+  .hdr-size { width: 72px; flex-shrink: 0; text-align: right; }
+
+  /* Message rows */
+  .msg-row { display: flex; align-items: center; padding: 0 8px; cursor: pointer; height: 100%; border-left: 3px solid transparent; transition: border-color 0.1s, background-color 0.1s; }
   .msg-row:hover { background: var(--vscode-list-hoverBackground); }
-  .selected { background: var(--vscode-list-activeSelectionBackground) !important; color: var(--vscode-list-activeSelectionForeground); }
-  .col-seq { width: 80px; flex-shrink: 0; }
+  .selected { background: var(--vscode-list-activeSelectionBackground) !important; color: var(--vscode-list-activeSelectionForeground); border-left-color: var(--vscode-focusBorder) !important; }
+  .col-seq { width: 72px; flex-shrink: 0; font-size: 0.9em; }
   .col-subject { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .col-ts { width: 200px; flex-shrink: 0; }
-  .col-size { width: 80px; flex-shrink: 0; text-align: right; }
-  th.col-seq { width: 80px; }
-  th.col-subject { }
-  th.col-ts { width: 200px; }
-  th.col-size { width: 80px; text-align: right; }
+  .col-ts { width: 120px; flex-shrink: 0; font-size: 0.85em; }
+  .col-size { width: 72px; flex-shrink: 0; text-align: right; font-size: 0.85em; }
   .mono { font-family: var(--vscode-editor-font-family); font-size: var(--vscode-editor-font-size); }
-  .detail-pane { border-top: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); max-height: 40vh; overflow: auto; padding: 8px; flex-shrink: 0; }
-  .detail-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; font-weight: 600; flex-wrap: wrap; gap: 4px; }
+
+  /* Detail pane */
+  .detail-pane { border-top: 2px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); max-height: 45vh; display: flex; flex-direction: column; flex-shrink: 0; }
+  .detail-toolbar { display: flex; align-items: center; justify-content: space-between; padding: 0 8px; flex-shrink: 0; border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); }
+  .detail-tabs { display: flex; gap: 0; }
+  .detail-tab { background: none; border: none; border-bottom: 2px solid transparent; border-radius: 0; padding: 6px 12px; min-height: auto; color: var(--vscode-foreground); opacity: 0.6; cursor: pointer; font-size: 0.9em; transition: opacity 0.15s, border-color 0.15s; }
+  .detail-tab:hover { opacity: 1; background: none; }
+  .detail-tab.active { border-bottom-color: var(--vscode-focusBorder); color: var(--vscode-focusBorder); opacity: 1; }
   .detail-actions { display: flex; gap: 4px; align-items: center; }
   .bookmark-input { width: 140px; font-size: 0.9em; }
-  .section { margin-bottom: 12px; }
-  .section h4 { margin: 4px 0; color: var(--vscode-descriptionForeground); font-size: 0.9em; }
-  .headers-table { width: auto; }
-  .header-key { font-weight: 600; white-space: nowrap; }
+
+  .detail-content { overflow: auto; padding: 8px 12px; flex: 1; min-height: 0; }
+
+  /* Payload */
+  .payload-header { display: flex; justify-content: flex-end; margin-bottom: 4px; }
+  .payload-pre { margin: 0; }
+  .json-viewer-wrap { padding: 4px 0; }
+
+  /* Headers / Info */
+  .headers-list, .info-list { padding: 4px 0; }
 </style>

--- a/webview-ui/src/panels/obj-viewer/App.svelte
+++ b/webview-ui/src/panels/obj-viewer/App.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import { vscode } from "../../lib/vscode-api";
+  import CopyButton from "../../lib/CopyButton.svelte";
+  import KeyValue from "../../lib/KeyValue.svelte";
+  import EmptyState from "../../lib/EmptyState.svelte";
 
   interface ObjectInfo {
     name: string;
@@ -14,6 +17,7 @@
   let objectName = $state("");
   let info = $state<ObjectInfo | null>(null);
   let loading = $state(true);
+  let confirmingDelete = $state(false);
 
   $effect(() => {
     const handler = (event: MessageEvent) => {
@@ -36,17 +40,25 @@
 
   function fetchInfo() {
     loading = true;
-    vscode.postMessage({ type: "obj:info", connectionId, store, name: objectName });
+    vscode.postMessage({
+      type: "obj:info",
+      connectionId,
+      store,
+      name: objectName,
+    });
   }
-
-  let confirmingDelete = $state(false);
 
   function deleteObject() {
     if (!confirmingDelete) {
       confirmingDelete = true;
       return;
     }
-    vscode.postMessage({ type: "obj:delete", connectionId, store, name: objectName });
+    vscode.postMessage({
+      type: "obj:delete",
+      connectionId,
+      store,
+      name: objectName,
+    });
     confirmingDelete = false;
   }
 
@@ -63,78 +75,161 @@
 
   function formatTimestamp(ts: string): string {
     if (!ts) return "-";
-    return ts.replace("T", " ").replace("Z", "");
+    return ts.replace("T", " ").replace("Z", " UTC");
+  }
+
+  function formatDigest(digest: string): string {
+    // Insert a space every 8 characters for readability
+    return digest.replace(/(.{8})/g, "$1 ").trim();
   }
 </script>
 
 <main>
-  <div class="header">
+  <!-- Breadcrumb header -->
+  <div class="obj-header">
     <div class="breadcrumb">
-      <span class="store-name">{store}</span>
-      <span class="sep">/</span>
-      <span class="object-name">{objectName}</span>
+      <span class="breadcrumb-store">{store}</span>
+      <span class="breadcrumb-sep">/</span>
+      <span class="breadcrumb-name">{objectName}</span>
     </div>
   </div>
 
   {#if loading}
-    <div class="loading">Loading...</div>
+    <EmptyState state="loading" message="Loading object info..." />
   {:else if !info}
-    <div class="empty">Object not found.</div>
+    <EmptyState state="error" message="Object not found." />
   {:else}
+    <!-- Actions toolbar -->
     <div class="toolbar">
       <button class="secondary" onclick={fetchInfo}>Refresh</button>
+      <div class="spacer"></div>
       {#if confirmingDelete}
-        <span class="confirm-text">Delete this object?</span>
-        <button class="danger" onclick={deleteObject}>Confirm</button>
+        <span class="confirm-label">Confirm delete?</span>
+        <button class="danger" onclick={deleteObject}>Confirm Delete</button>
         <button class="secondary" onclick={cancelDelete}>Cancel</button>
       {:else}
         <button class="danger" onclick={deleteObject}>Delete</button>
       {/if}
     </div>
 
-    <div class="info-pane">
-      <table class="info-table">
-        <tbody>
-          <tr>
-            <td class="label">Name</td>
-            <td>{info.name}</td>
-          </tr>
-          <tr>
-            <td class="label">Size</td>
-            <td>{formatBytes(info.size)}</td>
-          </tr>
-          <tr>
-            <td class="label">Chunks</td>
-            <td>{info.chunks}</td>
-          </tr>
-          <tr>
-            <td class="label">Last Modified</td>
-            <td class="mono">{formatTimestamp(info.lastModified)}</td>
-          </tr>
-          <tr>
-            <td class="label">Digest</td>
-            <td class="mono digest">{info.digest}</td>
-          </tr>
-        </tbody>
-      </table>
+    <!-- Metadata card -->
+    <div class="detail-card">
+      <div class="panel-section">
+        <KeyValue label="Name" value={info.name} mono copyable />
+        <KeyValue
+          label="Size"
+          value={`${formatBytes(info.size)} (${info.size.toLocaleString()} bytes)`}
+          copyable
+        />
+        <KeyValue label="Chunks" value={String(info.chunks)} />
+        <KeyValue
+          label="Last Modified"
+          value={formatTimestamp(info.lastModified)}
+          mono
+          copyable
+        />
+      </div>
+
+      <div class="panel-section">
+        <div class="digest-row">
+          <dt class="digest-label">Digest</dt>
+          <dd class="digest-value">
+            <code class="digest-code">{formatDigest(info.digest)}</code>
+            <CopyButton text={info.digest} label="Copy digest" />
+          </dd>
+        </div>
+      </div>
     </div>
   {/if}
 </main>
 
 <style>
-  main { display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
-  .header { padding: 8px; border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); flex-shrink: 0; }
-  .breadcrumb { font-weight: 600; font-size: 1.1em; display: flex; align-items: center; gap: 4px; }
-  .store-name { color: var(--vscode-descriptionForeground); }
-  .sep { color: var(--vscode-descriptionForeground); margin: 0 4px; }
-  .toolbar { display: flex; gap: 4px; padding: 8px; flex-shrink: 0; }
-  .info-pane { flex: 1; overflow: auto; padding: 0 8px; }
-  .info-table { width: 100%; border-collapse: collapse; }
-  .info-table td { padding: 6px 8px; border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); }
-  .label { font-weight: 600; color: var(--vscode-descriptionForeground); width: 120px; white-space: nowrap; }
-  .mono { font-family: var(--vscode-editor-font-family); font-size: var(--vscode-editor-font-size); }
-  .digest { word-break: break-all; }
-  .loading, .empty { padding: 24px; text-align: center; color: var(--vscode-descriptionForeground); }
-  .danger { color: var(--vscode-errorForeground); }
-  .confirm-text { color: var(--vscode-errorForeground); font-size: 0.9em; }
+  main {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .obj-header {
+    padding: var(--space-3);
+    border-bottom: 1px solid
+      var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+    flex-shrink: 0;
+  }
+
+  .breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    font-size: 1.05em;
+  }
+
+  .breadcrumb-store {
+    color: var(--vscode-descriptionForeground);
+    font-weight: 500;
+  }
+
+  .breadcrumb-sep {
+    color: var(--vscode-descriptionForeground);
+    margin: 0 4px;
+  }
+
+  .breadcrumb-name {
+    font-weight: 600;
+  }
+
+  .spacer {
+    flex: 1;
+  }
+
+  .confirm-label {
+    color: var(--vscode-errorForeground);
+    font-size: 0.9em;
+    font-weight: 500;
+  }
+
+  .detail-card {
+    flex: 1;
+    overflow: auto;
+    margin: var(--space-3);
+    border: 1px solid
+      var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+    border-radius: var(--radius-lg);
+    background: var(
+      --vscode-sideBar-background,
+      var(--vscode-editor-background)
+    );
+  }
+
+  .detail-card .panel-section:last-child {
+    border-bottom: none;
+  }
+
+  .digest-row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    padding: 3px 0;
+  }
+
+  .digest-label {
+    color: var(--vscode-descriptionForeground);
+    font-size: 0.85em;
+    min-width: 90px;
+    flex-shrink: 0;
+    padding-top: 2px;
+  }
+
+  .digest-value {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+
+  .digest-code {
+    word-break: break-all;
+    letter-spacing: 0.5px;
+  }
 </style>

--- a/webview-ui/src/panels/pub-sub/App.svelte
+++ b/webview-ui/src/panels/pub-sub/App.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { vscode } from "../../lib/vscode-api";
   import VirtualList from "../../lib/VirtualList.svelte";
+  import JsonViewer from "../../lib/JsonViewer.svelte";
+  import CopyButton from "../../lib/CopyButton.svelte";
+  import StatusBadge from "../../lib/StatusBadge.svelte";
+  import EmptyState from "../../lib/EmptyState.svelte";
+  import KeyValue from "../../lib/KeyValue.svelte";
+  import Sparkline from "../../lib/Sparkline.svelte";
 
   interface NatsMessage {
     subject: string;
@@ -34,15 +40,18 @@
   // Rate tracking
   let msgRate = $state(0);
   let rateCounter = 0;
+  let rateHistory = $state<number[]>([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
   // Publish state
   let pubSubject = $state("");
   let pubPayload = $state("");
   let pubHeaders = $state<{ key: string; value: string }[]>([]);
+  let publishedFeedback = $state(false);
 
   // Template state
   let templates = $state<Template[]>([]);
   let templateName = $state("");
+  let selectedTemplate = $state("");
 
   // Saved subscriptions (bookmarks)
   let savedSubscriptions = $state<{ name: string; subject: string }[]>([]);
@@ -71,6 +80,17 @@
           filterRegex!.test(m.subject) || filterRegex!.test(m.payload))
       : receivedMessages
   );
+
+  let filterMatchCount = $derived(
+    filterPattern.trim() ? filteredMessages.length : -1
+  );
+
+  // Parsed response payload
+  let parsedResponse = $derived.by(() => {
+    if (!reqResponse) return null;
+    if (reqResponse.payloadEncoding === "base64") return null;
+    try { return JSON.parse(reqResponse.payload); } catch { return null; }
+  });
 
   // Load templates from webview state
   $effect(() => {
@@ -110,6 +130,7 @@
     // Rate counter
     const rateInterval = setInterval(() => {
       msgRate = rateCounter;
+      rateHistory = [...rateHistory.slice(1), rateCounter];
       rateCounter = 0;
     }, 1000);
 
@@ -151,6 +172,8 @@
       payload: pubPayload,
       headers: Object.keys(hdrs).length > 0 ? hdrs : undefined,
     });
+    publishedFeedback = true;
+    setTimeout(() => { publishedFeedback = false; }, 1500);
   }
 
   function sendRequest() {
@@ -181,9 +204,15 @@
     pubHeaders = t.headers.length > 0 ? [...t.headers] : [];
   }
 
+  function loadTemplateByName(name: string) {
+    const t = templates.find(tmpl => tmpl.name === name);
+    if (t) loadTemplate(t);
+  }
+
   function deleteTemplate(name: string) {
     templates = templates.filter(t => t.name !== name);
     saveTemplates();
+    if (selectedTemplate === name) selectedTemplate = "";
   }
 
   function startSaveSub(id: string) {
@@ -223,9 +252,19 @@
     catch { return msg.payload; }
   }
 
+  function tryParseJson(payload: string): unknown | null {
+    try { return JSON.parse(payload); } catch { return null; }
+  }
+
   function formatSize(bytes: number): string {
     if (bytes < 1024) return `${bytes} B`;
     return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+
+  function formatTimestamp(ts: string): string {
+    try {
+      return new Date(ts).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    } catch { return ts; }
   }
 
   function getSubjectColor(subject: string): string {
@@ -241,29 +280,36 @@
     <button class:active={activeTab === "request"} onclick={() => (activeTab = "request")}>Request</button>
   </div>
 
+  <!-- ==================== SUBSCRIBE TAB ==================== -->
   {#if activeTab === "subscribe"}
     <div class="panel">
-      <div class="input-row">
-        <input type="text" bind:value={subSubject} placeholder="Subject (e.g. orders.>)"
-          class="subject-input" onkeydown={(e) => e.key === "Enter" && subscribe()} />
-        <button onclick={subscribe}>Subscribe</button>
-      </div>
-
+      <!-- Saved subscriptions -->
       {#if savedSubscriptions.length > 0}
-        <div class="saved-subs">
-          <span class="saved-label">Saved:</span>
+        <div class="saved-bar">
           {#each savedSubscriptions as saved}
-            <button class="secondary small" onclick={() => loadSavedSub(saved.subject)} title={saved.subject}>{saved.name}</button>
-            <button class="secondary small delete-btn" onclick={() => deleteSavedSub(saved.name)}>&times;</button>
+            <button class="saved-btn" onclick={() => loadSavedSub(saved.subject)} title={saved.subject}>
+              &#x2605; {saved.name}
+            </button>
+            <button class="icon-btn delete-x" onclick={() => deleteSavedSub(saved.name)} title="Remove saved">&times;</button>
           {/each}
         </div>
       {/if}
 
+      <!-- Subject input -->
+      <div class="sub-input-row">
+        <input type="text" bind:value={subSubject} placeholder="Subject (e.g. orders.>)"
+          class="subject-input" onkeydown={(e) => e.key === "Enter" && subscribe()} />
+        <button onclick={subscribe}>Subscribe</button>
+      </div>
+      <div class="input-hint">Use <code>*</code> for single token, <code>&gt;</code> for multiple</div>
+
+      <!-- Active subscriptions -->
       {#if subscriptions.length > 0}
-        <div class="sub-list">
+        <div class="sub-pills">
           {#each subscriptions as sub}
-            <span class="sub-tag" style="border-left: 3px solid {sub.color}">
-              {sub.subject}
+            <span class="sub-pill">
+              <span class="sub-dot" style="background: {sub.color}"></span>
+              <span class="sub-label">{sub.subject}</span>
               {#if savingSubId === sub.id}
                 <input
                   type="text"
@@ -275,124 +321,220 @@
                     if (e.key === "Escape") cancelSaveSub();
                   }}
                 />
-                <button class="sub-remove" onclick={() => confirmSaveSub(sub.subject)} title="Save">&#x2713;</button>
-                <button class="sub-remove" onclick={cancelSaveSub} title="Cancel">&times;</button>
+                <button class="icon-btn pill-action" onclick={() => confirmSaveSub(sub.subject)} title="Confirm">&#10003;</button>
+                <button class="icon-btn pill-action" onclick={cancelSaveSub} title="Cancel">&times;</button>
               {:else}
-                <button class="sub-remove" onclick={() => startSaveSub(sub.id)} title="Save subscription">&#x2605;</button>
-                <button class="sub-remove" onclick={() => unsubscribe(sub.id)}>&times;</button>
+                <button class="icon-btn pill-action" onclick={() => startSaveSub(sub.id)} title="Save subscription">&#x2605;</button>
+                <button class="icon-btn pill-action" onclick={() => unsubscribe(sub.id)} title="Unsubscribe">&times;</button>
               {/if}
             </span>
           {/each}
         </div>
       {/if}
 
+      <!-- Filter -->
       <div class="filter-row">
         <input type="text" bind:value={filterPattern} placeholder="Filter regex (subject or payload)..."
           class="filter-input" class:invalid={filterPattern && !filterRegex} />
-        {#if filterPattern && filteredMessages.length !== receivedMessages.length}
-          <span class="filter-count">{filteredMessages.length} / {receivedMessages.length}</span>
+        {#if filterMatchCount >= 0}
+          <StatusBadge status="info" label="{filteredMessages.length} / {receivedMessages.length} matched" />
         {/if}
       </div>
 
-      <div class="msg-controls">
-        <span class="msg-count">{msgCount} messages {msgRate > 0 ? `(${msgRate}/s)` : ""}</span>
-        <button class="secondary" onclick={() => (paused = !paused)}>{paused ? "Resume" : "Pause"}</button>
-        <button class="secondary" onclick={clearMessages}>Clear</button>
-        {#if receivedMessages.length > 0}
-          <button class="secondary" onclick={exportMessages}>Export</button>
-        {/if}
+      <!-- Stats bar -->
+      <div class="stats-bar">
+        <div class="stats-left">
+          <span class="stat-count">{msgCount.toLocaleString()} messages</span>
+          {#if msgRate > 0}
+            <StatusBadge status="success" label="{msgRate}/s" />
+          {/if}
+        </div>
+        <div class="stats-right">
+          <Sparkline values={rateHistory} fill showValue height={22} />
+          <button class="secondary small" onclick={() => (paused = !paused)}>
+            {paused ? "&#9654; Resume" : "&#10074;&#10074; Pause"}
+          </button>
+          <button class="secondary small" onclick={clearMessages}>Clear</button>
+          {#if receivedMessages.length > 0}
+            <button class="secondary small" onclick={exportMessages}>Export</button>
+          {/if}
+        </div>
       </div>
 
-      <VirtualList items={filteredMessages} itemHeight={52}>
-        {#snippet children({ item, index })}
-          {@const msg = item as NatsMessage}
-          <div class="feed-item" class:expanded={expandedMsg === index} onclick={() => expandedMsg = expandedMsg === index ? null : index}>
-            <div class="feed-meta">
-              <span class="feed-subject" style="color: {getSubjectColor(msg.subject)}">{msg.subject}</span>
-              <span class="feed-size">{formatSize(msg.size)}</span>
+      <!-- Message feed -->
+      {#if filteredMessages.length === 0}
+        <EmptyState state="empty" message="Waiting for messages..." />
+      {:else}
+        <VirtualList items={filteredMessages} itemHeight={56} totalLabel="messages">
+          {#snippet children({ item, index })}
+            {@const msg = item as NatsMessage}
+            <div class="feed-row" class:expanded={expandedMsg === index} onclick={() => expandedMsg = expandedMsg === index ? null : index}>
+              <div class="feed-top">
+                <span class="feed-subject" style="color: {getSubjectColor(msg.subject)}">{msg.subject}</span>
+                <span class="feed-meta-right">
+                  <span class="feed-time mono">{formatTimestamp(msg.timestamp)}</span>
+                  <span class="badge info">{formatSize(msg.size)}</span>
+                </span>
+              </div>
+              <div class="feed-preview mono">{msg.payload.slice(0, 100)}{msg.payload.length > 100 ? "..." : ""}</div>
             </div>
-            {#if expandedMsg === index}
-              <pre class="feed-payload-expanded">{formatPayload(msg)}</pre>
+          {/snippet}
+        </VirtualList>
+      {/if}
+
+      <!-- Expanded message overlay -->
+      {#if expandedMsg !== null && filteredMessages[expandedMsg]}
+        {@const exMsg = filteredMessages[expandedMsg]}
+        <div class="expanded-pane">
+          <div class="expanded-header">
+            <span class="feed-subject" style="color: {getSubjectColor(exMsg.subject)}">{exMsg.subject}</span>
+            <div class="expanded-actions">
+              <CopyButton text={exMsg.payload} label="Copy payload" />
+              <button class="icon-btn" onclick={() => expandedMsg = null} title="Close">&times;</button>
+            </div>
+          </div>
+          {#if exMsg.headers && Object.keys(exMsg.headers).length > 0}
+            <div class="expanded-section">
+              <div class="expanded-section-title">Headers</div>
+              {#each Object.entries(exMsg.headers) as [key, values]}
+                <KeyValue label={key} value={values.join(", ")} mono />
+              {/each}
+            </div>
+          {/if}
+          <div class="expanded-section">
+            {#if exMsg.payloadEncoding === "base64"}
+              <pre>[base64] {exMsg.payload}</pre>
+            {:else if tryParseJson(exMsg.payload) !== null}
+              <JsonViewer data={tryParseJson(exMsg.payload)} />
             {:else}
-              <div class="feed-preview">{msg.payload.slice(0, 120)}{msg.payload.length > 120 ? "..." : ""}</div>
+              <pre>{exMsg.payload}</pre>
             {/if}
           </div>
-        {/snippet}
-      </VirtualList>
-
-      {#if filteredMessages.length === 0}
-        <div class="empty">Waiting for messages...</div>
+        </div>
       {/if}
     </div>
 
+  <!-- ==================== PUBLISH TAB ==================== -->
   {:else if activeTab === "publish"}
-    <div class="panel">
+    <div class="panel pub-panel">
+      <!-- Templates -->
       {#if templates.length > 0}
-        <div class="templates-bar">
-          <span class="templates-label">Templates:</span>
-          {#each templates as t}
-            <button class="secondary small" onclick={() => loadTemplate(t)} title={t.subject}>{t.name}</button>
-            <button class="secondary small delete-btn" onclick={() => deleteTemplate(t.name)}>&times;</button>
-          {/each}
+        <div class="template-section">
+          <div class="template-row">
+            <select class="template-select" bind:value={selectedTemplate} onchange={() => selectedTemplate && loadTemplateByName(selectedTemplate)}>
+              <option value="">-- Select template --</option>
+              {#each templates as t}
+                <option value={t.name}>{t.name} ({t.subject})</option>
+              {/each}
+            </select>
+            {#if selectedTemplate}
+              <button class="icon-btn" onclick={() => deleteTemplate(selectedTemplate)} title="Delete template">&#128465;</button>
+            {/if}
+          </div>
         </div>
       {/if}
 
+      <!-- Subject -->
       <div class="field">
         <label for="pub-subject">Subject</label>
         <input id="pub-subject" type="text" bind:value={pubSubject} placeholder="e.g. orders.created" />
       </div>
 
+      <!-- Headers -->
       <div class="field">
-        <label>
-          Headers
-          <button class="secondary small" onclick={addHeader}>+ Add</button>
-        </label>
-        {#each pubHeaders as header, i}
-          <div class="header-row">
-            <input type="text" bind:value={header.key} placeholder="Key" />
-            <input type="text" bind:value={header.value} placeholder="Value" />
-            <button class="secondary small" onclick={() => removeHeader(i)}>&times;</button>
-          </div>
-        {/each}
-      </div>
-
-      <div class="field">
-        <label for="pub-payload">Payload</label>
-        <textarea id="pub-payload" bind:value={pubPayload} rows={8} placeholder="Message payload..."></textarea>
-      </div>
-
-      <div class="button-row">
-        <button onclick={publish}>Publish</button>
-        <div class="save-template">
-          <input type="text" bind:value={templateName} placeholder="Template name..." class="template-name" />
-          <button class="secondary" onclick={saveTemplate} disabled={!templateName.trim()}>Save Template</button>
+        <div class="field-header">
+          <label>Headers</label>
+          <button class="secondary small" onclick={addHeader}>+ Add Header</button>
         </div>
+        {#if pubHeaders.length > 0}
+          <div class="headers-grid">
+            {#each pubHeaders as header, i}
+              <div class="header-row">
+                <input type="text" bind:value={header.key} placeholder="Header name" />
+                <input type="text" bind:value={header.value} placeholder="Header value" />
+                <button class="icon-btn" onclick={() => removeHeader(i)} title="Remove header">&times;</button>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+
+      <!-- Payload -->
+      <div class="field payload-field">
+        <label for="pub-payload">Payload</label>
+        <textarea id="pub-payload" bind:value={pubPayload} rows={12} placeholder="Message payload..." class="mono-textarea"></textarea>
+      </div>
+
+      <!-- Publish button -->
+      <button class="publish-btn" onclick={publish} disabled={!pubSubject.trim()}>
+        {#if publishedFeedback}
+          &#10003; Sent
+        {:else}
+          Publish Message
+        {/if}
+      </button>
+
+      <!-- Save template -->
+      <div class="save-template-row">
+        <input type="text" bind:value={templateName} placeholder="Template name..." class="template-name-input" />
+        <button class="secondary" onclick={saveTemplate} disabled={!templateName.trim()}>Save as Template</button>
       </div>
     </div>
 
+  <!-- ==================== REQUEST TAB ==================== -->
   {:else if activeTab === "request"}
-    <div class="panel">
+    <div class="panel req-panel">
+      <!-- Subject -->
       <div class="field">
         <label for="req-subject">Subject</label>
         <input id="req-subject" type="text" bind:value={reqSubject} placeholder="e.g. service.endpoint" />
       </div>
-      <div class="field">
-        <label for="req-timeout">Timeout (ms)</label>
-        <input id="req-timeout" type="number" bind:value={reqTimeout} />
-      </div>
+
+      <!-- Payload -->
       <div class="field">
         <label for="req-payload">Payload</label>
-        <textarea id="req-payload" bind:value={reqPayload} rows={6} placeholder="Request payload..."></textarea>
+        <textarea id="req-payload" bind:value={reqPayload} rows={6} placeholder="Request payload..." class="mono-textarea"></textarea>
       </div>
-      <button onclick={sendRequest} disabled={reqLoading}>{reqLoading ? "Waiting..." : "Send Request"}</button>
+
+      <!-- Timeout -->
+      <div class="field">
+        <label for="req-timeout">Timeout</label>
+        <select id="req-timeout" bind:value={reqTimeout}>
+          <option value={1000}>1 second</option>
+          <option value={5000}>5 seconds</option>
+          <option value={10000}>10 seconds</option>
+          <option value={30000}>30 seconds</option>
+        </select>
+      </div>
+
+      <!-- Send button -->
+      <button class="publish-btn" onclick={sendRequest} disabled={reqLoading || !reqSubject.trim()}>
+        {#if reqLoading}
+          Waiting for response...
+        {:else}
+          Send Request
+        {/if}
+      </button>
+
+      <!-- Response -->
       {#if reqResponse}
-        <div class="response">
-          <h4>Response ({reqDuration}ms)</h4>
-          <pre>{formatPayload(reqResponse)}</pre>
+        <div class="response-section">
+          <div class="response-header">
+            <StatusBadge status="success" label="Response received" />
+            <span class="badge info">{reqDuration}ms</span>
+          </div>
+          <div class="response-body">
+            {#if parsedResponse !== null}
+              <JsonViewer data={parsedResponse} />
+            {:else}
+              <pre>{formatPayload(reqResponse)}</pre>
+            {/if}
+          </div>
         </div>
       {/if}
+
       {#if reqError}
-        <div class="error-msg">{reqError}</div>
+        <EmptyState state="error" message={reqError} />
       {/if}
     </div>
   {/if}
@@ -400,46 +542,75 @@
 
 <style>
   main { display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
-  .tabs { display: flex; border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); flex-shrink: 0; }
-  .tabs button { flex: 1; padding: 8px; background: none; color: var(--vscode-foreground); border: none; border-bottom: 2px solid transparent; cursor: pointer; }
-  .tabs button.active { border-bottom-color: var(--vscode-focusBorder); color: var(--vscode-focusBorder); }
-  .panel { flex: 1; overflow: auto; padding: 8px; display: flex; flex-direction: column; }
-  .input-row { display: flex; gap: 4px; margin-bottom: 8px; }
+  .panel { flex: 1; overflow: auto; padding: 8px 12px; display: flex; flex-direction: column; gap: 8px; }
+
+  /* ---- Subscribe tab ---- */
+  .saved-bar { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; padding: 6px 8px; background: var(--vscode-sideBar-background, var(--vscode-editor-background)); border-radius: var(--radius); }
+  .saved-btn { min-height: 22px; padding: 2px 8px; font-size: 0.82em; background: none; border: 1px solid var(--vscode-widget-border, rgba(128,128,128,0.3)); color: var(--vscode-textLink-foreground); border-radius: 10px; }
+  .saved-btn:hover { background: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31)); }
+  .delete-x { margin-left: -6px; font-size: 0.85em; }
+
+  .sub-input-row { display: flex; gap: 4px; }
   .subject-input { flex: 1; }
-  .sub-list { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 8px; }
-  .sub-tag { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; background: var(--vscode-badge-background); color: var(--vscode-badge-foreground); border-radius: 10px; font-size: 0.85em; }
-  .sub-remove { background: none; border: none; color: inherit; padding: 0 2px; cursor: pointer; font-size: 1.1em; }
-  .filter-row { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
+  .input-hint { font-size: 0.8em; color: var(--vscode-descriptionForeground); margin-top: -4px; }
+  .input-hint code { font-size: 1em; padding: 0 3px; }
+
+  .sub-pills { display: flex; flex-wrap: wrap; gap: 6px; }
+  .sub-pill { display: inline-flex; align-items: center; gap: 6px; padding: 3px 8px 3px 6px; background: var(--vscode-badge-background); color: var(--vscode-badge-foreground); border-radius: 12px; font-size: 0.85em; }
+  .sub-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+  .sub-label { white-space: nowrap; }
+  .pill-action { padding: 0 2px !important; min-height: auto !important; font-size: 1em; }
+  .save-sub-input { width: 80px; padding: 1px 4px; font-size: 0.85em; border-radius: 3px; }
+
+  .filter-row { display: flex; gap: 8px; align-items: center; }
   .filter-input { flex: 1; }
   .filter-input.invalid { border-color: var(--vscode-inputValidation-errorBorder, #be1100); }
-  .filter-count { font-size: 0.85em; color: var(--vscode-descriptionForeground); white-space: nowrap; }
-  .msg-controls { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; flex-shrink: 0; }
-  .msg-count { flex: 1; color: var(--vscode-descriptionForeground); font-size: 0.9em; }
-  .feed-item { border-bottom: 1px solid var(--vscode-widget-border, transparent); padding: 4px 8px; cursor: pointer; }
-  .feed-item:hover { background: var(--vscode-list-hoverBackground); }
-  .feed-meta { display: flex; justify-content: space-between; font-size: 0.85em; }
-  .feed-subject { font-weight: 600; }
-  .feed-size { color: var(--vscode-descriptionForeground); }
-  .feed-preview { font-family: var(--vscode-editor-font-family); font-size: 0.8em; color: var(--vscode-descriptionForeground); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .feed-payload-expanded { margin: 4px 0 0 0; padding: 4px; font-size: 0.8em; max-height: 200px; overflow: auto; }
-  .empty { padding: 24px; text-align: center; color: var(--vscode-descriptionForeground); }
-  .field { margin-bottom: 12px; }
-  .field label { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; font-weight: 600; font-size: 0.9em; }
-  .field input, .field textarea { width: 100%; }
-  .field textarea { font-family: var(--vscode-editor-font-family); resize: vertical; }
-  .header-row { display: flex; gap: 4px; margin-bottom: 4px; }
+
+  .stats-bar { display: flex; align-items: center; justify-content: space-between; padding: 4px 0; flex-shrink: 0; }
+  .stats-left { display: flex; align-items: center; gap: 8px; }
+  .stat-count { font-size: 0.9em; color: var(--vscode-descriptionForeground); font-variant-numeric: tabular-nums; }
+  .stats-right { display: flex; align-items: center; gap: 6px; }
+
+  /* Feed rows */
+  .feed-row { padding: 4px 8px; cursor: pointer; border-bottom: 1px solid var(--vscode-widget-border, transparent); height: 100%; display: flex; flex-direction: column; justify-content: center; }
+  .feed-row:hover { background: var(--vscode-list-hoverBackground); }
+  .feed-top { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+  .feed-subject { font-weight: 600; font-size: 0.9em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .feed-meta-right { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+  .feed-time { font-size: 0.8em; color: var(--vscode-descriptionForeground); }
+  .feed-preview { font-size: 0.8em; color: var(--vscode-descriptionForeground); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-top: 2px; }
+  .mono { font-family: var(--vscode-editor-font-family); font-size: var(--vscode-editor-font-size); }
+
+  /* Expanded message */
+  .expanded-pane { border-top: 2px solid var(--vscode-panel-border, var(--vscode-widget-border, transparent)); max-height: 40vh; overflow: auto; padding: 8px 12px; flex-shrink: 0; }
+  .expanded-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+  .expanded-actions { display: flex; align-items: center; gap: 4px; }
+  .expanded-section { margin-bottom: 8px; }
+  .expanded-section-title { font-size: 0.8em; font-weight: 600; color: var(--vscode-descriptionForeground); text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: 4px; }
+
+  /* ---- Publish tab ---- */
+  .pub-panel { gap: 12px; }
+  .template-section { margin-bottom: 4px; }
+  .template-row { display: flex; gap: 4px; align-items: center; }
+  .template-select { flex: 1; min-height: 28px; }
+
+  .field { display: flex; flex-direction: column; gap: 4px; }
+  .field label { font-weight: 600; font-size: 0.9em; }
+  .field input, .field textarea, .field select { width: 100%; }
+  .field-header { display: flex; align-items: center; justify-content: space-between; }
+  .headers-grid { display: flex; flex-direction: column; gap: 4px; }
+  .header-row { display: flex; gap: 4px; align-items: center; }
   .header-row input { flex: 1; }
-  .small { padding: 2px 6px; font-size: 0.85em; }
-  .button-row { display: flex; gap: 8px; align-items: center; }
-  .save-template { display: flex; gap: 4px; align-items: center; margin-left: auto; }
-  .template-name { width: 140px; }
-  .templates-bar { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; margin-bottom: 12px; padding: 6px; background: var(--vscode-sideBar-background, var(--vscode-editor-background)); border-radius: 4px; }
-  .templates-label { font-size: 0.85em; color: var(--vscode-descriptionForeground); margin-right: 4px; }
-  .delete-btn { color: var(--vscode-errorForeground); padding: 2px 4px; }
-  .saved-subs { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; margin-bottom: 8px; padding: 6px; background: var(--vscode-sideBar-background, var(--vscode-editor-background)); border-radius: 4px; }
-  .saved-label { font-size: 0.85em; color: var(--vscode-descriptionForeground); margin-right: 4px; }
-  .save-sub-input { width: 80px; padding: 1px 4px; font-size: 0.85em; }
-  .response { margin-top: 12px; border: 1px solid var(--vscode-widget-border, transparent); border-radius: 4px; padding: 8px; }
-  .response h4 { margin: 0 0 4px 0; font-size: 0.9em; color: var(--vscode-descriptionForeground); }
-  .error-msg { margin-top: 8px; padding: 8px; background: var(--vscode-inputValidation-errorBackground, #5a1d1d); border: 1px solid var(--vscode-inputValidation-errorBorder, #be1100); border-radius: 4px; color: var(--vscode-errorForeground); }
+  .payload-field { flex: 1; min-height: 0; }
+  .mono-textarea { font-family: var(--vscode-editor-font-family); resize: vertical; }
+
+  .publish-btn { width: 100%; min-height: 34px; font-weight: 600; }
+  .save-template-row { display: flex; gap: 4px; align-items: center; }
+  .template-name-input { flex: 1; }
+
+  /* ---- Request tab ---- */
+  .req-panel { gap: 12px; }
+  .response-section { margin-top: 8px; border: 1px solid var(--vscode-widget-border, transparent); border-radius: var(--radius-lg); overflow: hidden; }
+  .response-header { display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--vscode-sideBar-background, var(--vscode-editor-background)); border-bottom: 1px solid var(--vscode-widget-border, transparent); }
+  .response-body { padding: 8px 12px; }
 </style>

--- a/webview-ui/src/panels/server-monitor/App.svelte
+++ b/webview-ui/src/panels/server-monitor/App.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { vscode } from "../../lib/vscode-api";
   import Sparkline from "../../lib/Sparkline.svelte";
+  import StatusBadge from "../../lib/StatusBadge.svelte";
+  import EmptyState from "../../lib/EmptyState.svelte";
 
   interface VarzData {
     server_id: string;
@@ -74,13 +76,16 @@
   }
 
   let connectionId = $state("");
-  let activeTab = $state<"server" | "connections" | "jetstream" | "accounts">("server");
+  let activeTab = $state<"server" | "connections" | "jetstream" | "accounts">(
+    "server"
+  );
 
   let varz = $state<VarzData | null>(null);
   let connz = $state<ConnzData | null>(null);
   let jsz = $state<JszData | null>(null);
   let accountz = $state<AccountzData | null>(null);
   let error = $state("");
+  let connFilter = $state("");
 
   // Sparkline history
   let cpuHistory = $state<number[]>([]);
@@ -89,6 +94,31 @@
   let msgsOutHistory = $state<number[]>([]);
 
   const MAX_HISTORY = 30;
+
+  let filteredConnections = $derived(
+    connz
+      ? connFilter
+        ? connz.connections.filter(
+            (c) =>
+              (c.name || "").toLowerCase().includes(connFilter.toLowerCase()) ||
+              c.ip.includes(connFilter) ||
+              c.lang.toLowerCase().includes(connFilter.toLowerCase())
+          )
+        : connz.connections
+      : []
+  );
+
+  let memoryPct = $derived(
+    jsz?.config?.max_memory && jsz.config.max_memory > 0
+      ? (jsz.memory / jsz.config.max_memory) * 100
+      : 0
+  );
+
+  let storagePct = $derived(
+    jsz?.config?.max_store && jsz.config.max_store > 0
+      ? (jsz.storage / jsz.config.max_store) * 100
+      : 0
+  );
 
   function formatBytes(bytes: number): string {
     if (bytes === 0) return "0 B";
@@ -165,100 +195,186 @@
     >
     <button
       class:active={activeTab === "connections"}
-      onclick={() => (activeTab = "connections")}>Connections</button
+      onclick={() => (activeTab = "connections")}
     >
+      Connections
+      {#if connz}
+        <span class="tab-badge">{connz.num_connections}</span>
+      {/if}
+    </button>
     <button
       class:active={activeTab === "jetstream"}
       onclick={() => (activeTab = "jetstream")}>JetStream</button
     >
     <button
       class:active={activeTab === "accounts"}
-      onclick={() => (activeTab = "accounts")}>Accounts</button
+      onclick={() => (activeTab = "accounts")}
     >
+      Accounts
+      {#if accountz}
+        <span class="tab-badge">{accountz.accounts.length}</span>
+      {/if}
+    </button>
   </div>
 
   {#if error}
     <div class="error-msg">{error}</div>
   {/if}
 
+  <!-- Server Tab -->
   {#if activeTab === "server"}
     <div class="panel">
       {#if varz}
+        <!-- Hero section -->
+        <div class="hero-section">
+          <div class="hero-name">
+            {varz.server_name || varz.server_id.slice(0, 8)}
+          </div>
+          <div class="hero-meta">
+            <span class="badge info">v{varz.version}</span>
+            <span class="hero-uptime">up {varz.uptime}</span>
+            <span class="hero-detail"
+              >{varz.host}:{varz.port}</span
+            >
+          </div>
+        </div>
+
         <div class="stat-grid">
-          <div class="stat-card">
-            <div class="stat-label">Server Name</div>
-            <div class="stat-value">{varz.server_name || varz.server_id.slice(0, 8)}</div>
+          <!-- CPU card with large sparkline -->
+          <div class="stat-card stat-card-wide">
+            <div class="stat-header">
+              <span class="stat-label">CPU</span>
+              <span class="stat-value">{varz.cpu.toFixed(1)}%</span>
+            </div>
+            <div class="sparkline-large">
+              <Sparkline
+                values={cpuHistory}
+                color="var(--vscode-charts-yellow, #cca700)"
+                fill
+                showValue
+              />
+            </div>
           </div>
-          <div class="stat-card">
-            <div class="stat-label">Version</div>
-            <div class="stat-value">{varz.version}</div>
+
+          <!-- Memory card with large sparkline -->
+          <div class="stat-card stat-card-wide">
+            <div class="stat-header">
+              <span class="stat-label">Memory</span>
+              <span class="stat-value">{formatBytes(varz.mem)}</span>
+            </div>
+            <div class="sparkline-large">
+              <Sparkline
+                values={memHistory}
+                color="var(--vscode-charts-purple, #b180d7)"
+                fill
+                showValue
+              />
+            </div>
           </div>
-          <div class="stat-card">
-            <div class="stat-label">Uptime</div>
-            <div class="stat-value">{varz.uptime}</div>
+
+          <!-- Messages In -->
+          <div class="stat-card stat-card-wide">
+            <div class="stat-header">
+              <span class="stat-label">Messages In</span>
+              <span class="stat-value">{formatCount(varz.in_msgs)}</span>
+            </div>
+            <div class="sparkline-large">
+              <Sparkline
+                values={msgsInHistory}
+                color="var(--vscode-charts-green, #89d185)"
+                fill
+                showValue
+              />
+            </div>
           </div>
-          <div class="stat-card">
-            <div class="stat-label">Go</div>
-            <div class="stat-value">{varz.go}</div>
+
+          <!-- Messages Out -->
+          <div class="stat-card stat-card-wide">
+            <div class="stat-header">
+              <span class="stat-label">Messages Out</span>
+              <span class="stat-value">{formatCount(varz.out_msgs)}</span>
+            </div>
+            <div class="sparkline-large">
+              <Sparkline
+                values={msgsOutHistory}
+                color="var(--vscode-charts-blue, #3794ff)"
+                fill
+                showValue
+              />
+            </div>
           </div>
-          <div class="stat-card">
-            <div class="stat-label">CPU</div>
-            <div class="stat-value">{varz.cpu.toFixed(1)}%</div>
-            <Sparkline values={cpuHistory} color="var(--vscode-charts-yellow, #cca700)" />
-          </div>
-          <div class="stat-card">
-            <div class="stat-label">Memory</div>
-            <div class="stat-value">{formatBytes(varz.mem)}</div>
-            <Sparkline values={memHistory} color="var(--vscode-charts-purple, #b180d7)" />
-          </div>
+
+          <!-- Simple value cards -->
           <div class="stat-card">
             <div class="stat-label">Cores</div>
             <div class="stat-value">{varz.cores}</div>
           </div>
+
           <div class="stat-card">
             <div class="stat-label">Connections</div>
-            <div class="stat-value">{varz.connections} / {varz.max_connections}</div>
+            <div class="stat-value">
+              {varz.connections} / {varz.max_connections}
+            </div>
           </div>
+
           <div class="stat-card">
             <div class="stat-label">Total Connections</div>
             <div class="stat-value">{formatCount(varz.total_connections)}</div>
           </div>
-          <div class="stat-card">
-            <div class="stat-label">Messages In</div>
-            <div class="stat-value">{formatCount(varz.in_msgs)}</div>
-            <Sparkline values={msgsInHistory} color="var(--vscode-charts-green, #89d185)" />
-          </div>
-          <div class="stat-card">
-            <div class="stat-label">Messages Out</div>
-            <div class="stat-value">{formatCount(varz.out_msgs)}</div>
-            <Sparkline values={msgsOutHistory} color="var(--vscode-charts-blue, #3794ff)" />
-          </div>
+
           <div class="stat-card">
             <div class="stat-label">Data In</div>
             <div class="stat-value">{formatBytes(varz.in_bytes)}</div>
           </div>
+
           <div class="stat-card">
             <div class="stat-label">Data Out</div>
             <div class="stat-value">{formatBytes(varz.out_bytes)}</div>
           </div>
+
           <div class="stat-card">
             <div class="stat-label">Subscriptions</div>
             <div class="stat-value">{formatCount(varz.subscriptions)}</div>
           </div>
+
+          <div class="stat-card">
+            <div class="stat-label">Go Runtime</div>
+            <div class="stat-value stat-value-small">{varz.go}</div>
+          </div>
+
           <div class="stat-card">
             <div class="stat-label">Slow Consumers</div>
-            <div class="stat-value" class:warn={varz.slow_consumers > 0}>{varz.slow_consumers}</div>
+            <div class="stat-value">
+              {#if varz.slow_consumers > 0}
+                <StatusBadge
+                  status="warning"
+                  label={String(varz.slow_consumers)}
+                />
+              {:else}
+                0
+              {/if}
+            </div>
           </div>
         </div>
       {:else if !error}
-        <div class="empty">Loading server info...</div>
+        <EmptyState state="loading" message="Loading server info..." />
       {/if}
     </div>
+
+  <!-- Connections Tab -->
   {:else if activeTab === "connections"}
     <div class="panel">
       {#if connz}
-        <div class="table-info">
-          {connz.num_connections} active connection{connz.num_connections !== 1 ? "s" : ""}
+        <div class="conn-toolbar">
+          <input
+            type="text"
+            bind:value={connFilter}
+            placeholder="Filter by name, IP, or language..."
+            class="conn-filter"
+          />
+          <span class="conn-count"
+            >{filteredConnections.length} of {connz.num_connections} connections</span
+          >
         </div>
         <div class="table-wrap">
           <table>
@@ -270,36 +386,38 @@
                 <th>Version</th>
                 <th>RTT</th>
                 <th>Uptime</th>
-                <th>Msgs In</th>
-                <th>Msgs Out</th>
-                <th>Data In</th>
-                <th>Data Out</th>
-                <th>Subs</th>
+                <th class="th-num">Msgs In</th>
+                <th class="th-num">Msgs Out</th>
+                <th class="th-num">Data In</th>
+                <th class="th-num">Data Out</th>
+                <th class="th-num">Subs</th>
               </tr>
             </thead>
             <tbody>
-              {#each connz.connections as conn}
+              {#each filteredConnections as conn}
                 <tr>
                   <td class="name-cell">{conn.name || "-"}</td>
-                  <td>{conn.ip}:{conn.port}</td>
+                  <td class="mono">{conn.ip}:{conn.port}</td>
                   <td>{conn.lang}</td>
                   <td>{conn.version}</td>
-                  <td>{conn.rtt}</td>
+                  <td class="mono">{conn.rtt}</td>
                   <td>{conn.uptime}</td>
-                  <td class="num">{formatCount(conn.in_msgs)}</td>
-                  <td class="num">{formatCount(conn.out_msgs)}</td>
-                  <td class="num">{formatBytes(conn.in_bytes)}</td>
-                  <td class="num">{formatBytes(conn.out_bytes)}</td>
-                  <td class="num">{conn.subscriptions}</td>
+                  <td class="num mono">{formatCount(conn.in_msgs)}</td>
+                  <td class="num mono">{formatCount(conn.out_msgs)}</td>
+                  <td class="num mono">{formatBytes(conn.in_bytes)}</td>
+                  <td class="num mono">{formatBytes(conn.out_bytes)}</td>
+                  <td class="num mono">{conn.subscriptions}</td>
                 </tr>
               {/each}
             </tbody>
           </table>
         </div>
       {:else if !error}
-        <div class="empty">Loading connections...</div>
+        <EmptyState state="loading" message="Loading connections..." />
       {/if}
     </div>
+
+  <!-- JetStream Tab -->
   {:else if activeTab === "jetstream"}
     <div class="panel">
       {#if jsz}
@@ -308,67 +426,128 @@
             <div class="stat-label">Streams</div>
             <div class="stat-value">{jsz.total_streams}</div>
           </div>
+
           <div class="stat-card">
             <div class="stat-label">Consumers</div>
             <div class="stat-value">{jsz.total_consumers}</div>
           </div>
-          <div class="stat-card">
-            <div class="stat-label">Memory Used</div>
-            <div class="stat-value">{formatBytes(jsz.memory)}</div>
-          </div>
-          <div class="stat-card">
-            <div class="stat-label">Storage Used</div>
-            <div class="stat-value">{formatBytes(jsz.storage)}</div>
-          </div>
-          {#if jsz.config}
-            <div class="stat-card">
-              <div class="stat-label">Max Memory</div>
-              <div class="stat-value">{formatBytes(jsz.config.max_memory)}</div>
+
+          <!-- Memory usage with progress bar -->
+          <div class="stat-card stat-card-wide">
+            <div class="stat-header">
+              <span class="stat-label">Memory Used</span>
+              <span class="stat-value">{formatBytes(jsz.memory)}</span>
             </div>
-            <div class="stat-card">
-              <div class="stat-label">Max Storage</div>
-              <div class="stat-value">{formatBytes(jsz.config.max_store)}</div>
+            {#if jsz.config && jsz.config.max_memory > 0}
+              <div class="progress-row">
+                <div class="progress-bar">
+                  <div
+                    class="progress-fill"
+                    class:progress-warn={memoryPct > 80}
+                    style="width: {Math.min(memoryPct, 100)}%"
+                  ></div>
+                </div>
+                <span class="progress-label"
+                  >{memoryPct.toFixed(1)}% of {formatBytes(
+                    jsz.config.max_memory
+                  )}</span
+                >
+              </div>
+            {/if}
+          </div>
+
+          <!-- Storage usage with progress bar -->
+          <div class="stat-card stat-card-wide">
+            <div class="stat-header">
+              <span class="stat-label">Storage Used</span>
+              <span class="stat-value">{formatBytes(jsz.storage)}</span>
             </div>
-          {/if}
+            {#if jsz.config && jsz.config.max_store > 0}
+              <div class="progress-row">
+                <div class="progress-bar">
+                  <div
+                    class="progress-fill"
+                    class:progress-warn={storagePct > 80}
+                    style="width: {Math.min(storagePct, 100)}%"
+                  ></div>
+                </div>
+                <span class="progress-label"
+                  >{storagePct.toFixed(1)}% of {formatBytes(
+                    jsz.config.max_store
+                  )}</span
+                >
+              </div>
+            {/if}
+          </div>
+
           <div class="stat-card">
             <div class="stat-label">API Calls</div>
             <div class="stat-value">{formatCount(jsz.api.total)}</div>
           </div>
+
           <div class="stat-card">
             <div class="stat-label">API Errors</div>
-            <div class="stat-value" class:warn={jsz.api.errors > 0}>{formatCount(jsz.api.errors)}</div>
+            <div class="stat-value">
+              {#if jsz.api.errors > 0}
+                <StatusBadge
+                  status="error"
+                  label={formatCount(jsz.api.errors)}
+                />
+              {:else}
+                0
+              {/if}
+            </div>
           </div>
+
+          {#if jsz.config}
+            <div class="stat-card">
+              <div class="stat-label">Max Memory</div>
+              <div class="stat-value">
+                {formatBytes(jsz.config.max_memory)}
+              </div>
+            </div>
+
+            <div class="stat-card">
+              <div class="stat-label">Max Storage</div>
+              <div class="stat-value">
+                {formatBytes(jsz.config.max_store)}
+              </div>
+            </div>
+          {/if}
         </div>
       {:else if !error}
-        <div class="empty">Loading JetStream info...</div>
+        <EmptyState state="loading" message="Loading JetStream info..." />
       {/if}
     </div>
+
+  <!-- Accounts Tab -->
   {:else if activeTab === "accounts"}
     <div class="panel">
       {#if accountz}
-        <div class="table-info">
-          {accountz.accounts.length} account{accountz.accounts.length !== 1 ? "s" : ""}
-        </div>
-        <div class="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>Account</th>
-              </tr>
-            </thead>
-            <tbody>
-              {#each accountz.accounts as account, i}
+        {#if accountz.accounts.length === 0}
+          <EmptyState state="empty" message="No accounts found." />
+        {:else}
+          <div class="table-wrap">
+            <table>
+              <thead>
                 <tr>
-                  <td class="num">{i + 1}</td>
-                  <td class="mono">{account}</td>
+                  <th class="th-num">#</th>
+                  <th>Account</th>
                 </tr>
-              {/each}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {#each accountz.accounts as account, i}
+                  <tr>
+                    <td class="num mono">{i + 1}</td>
+                    <td class="mono">{account}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+        {/if}
       {:else if !error}
-        <div class="empty">Loading accounts...</div>
+        <EmptyState state="loading" message="Loading accounts..." />
       {/if}
     </div>
   {/if}
@@ -381,70 +560,165 @@
     height: 100vh;
     overflow: hidden;
   }
-  .tabs {
-    display: flex;
-    border-bottom: 1px solid
-      var(--vscode-panel-border, var(--vscode-widget-border, transparent));
-    flex-shrink: 0;
-  }
-  .tabs button {
-    flex: 1;
-    padding: 8px;
-    background: none;
-    color: var(--vscode-foreground);
-    border: none;
-    border-bottom: 2px solid transparent;
-    cursor: pointer;
-  }
-  .tabs button.active {
-    border-bottom-color: var(--vscode-focusBorder);
-    color: var(--vscode-focusBorder);
-  }
+
   .panel {
     flex: 1;
     overflow: auto;
-    padding: 12px;
+    padding: var(--space-3);
   }
+
+  /* Hero section */
+  .hero-section {
+    margin-bottom: var(--space-4);
+    padding-bottom: var(--space-3);
+    border-bottom: 1px solid
+      var(--vscode-panel-border, var(--vscode-widget-border, transparent));
+  }
+
+  .hero-name {
+    font-size: 1.6em;
+    font-weight: 700;
+    margin-bottom: var(--space-1);
+  }
+
+  .hero-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .hero-uptime {
+    color: var(--vscode-descriptionForeground);
+    font-size: 0.9em;
+  }
+
+  .hero-detail {
+    color: var(--vscode-descriptionForeground);
+    font-size: 0.9em;
+    font-family: var(--vscode-editor-font-family);
+  }
+
+  /* Stat grid */
   .stat-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-    gap: 8px;
+    gap: var(--space-2);
   }
+
   .stat-card {
     background: var(
       --vscode-sideBar-background,
       var(--vscode-editor-background)
     );
     border: 1px solid var(--vscode-widget-border, transparent);
-    border-radius: 4px;
-    padding: 10px;
+    border-radius: var(--radius-lg);
+    padding: var(--space-3);
   }
+
+  .stat-card-wide {
+    grid-column: span 2;
+  }
+
+  .stat-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: var(--space-1);
+  }
+
   .stat-label {
     font-size: 0.8em;
     color: var(--vscode-descriptionForeground);
     margin-bottom: 2px;
   }
+
   .stat-value {
     font-size: 1.2em;
     font-weight: 600;
-    margin-bottom: 4px;
+    margin-bottom: var(--space-1);
   }
-  .stat-value.warn {
-    color: var(--vscode-charts-yellow, #cca700);
+
+  .stat-value-small {
+    font-size: 0.95em;
   }
-  .table-info {
-    font-size: 0.9em;
+
+  .sparkline-large {
+    margin-top: var(--space-1);
+  }
+
+  .sparkline-large :global(.sparkline-wrap) {
+    width: 100%;
+  }
+
+  .sparkline-large :global(.sparkline) {
+    max-width: none;
+    height: 36px;
+  }
+
+  /* Progress bars */
+  .progress-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-1);
+  }
+
+  .progress-bar {
+    flex: 1;
+    height: 6px;
+    background: var(--vscode-progressBar-background, rgba(128, 128, 128, 0.2));
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .progress-fill {
+    height: 100%;
+    background: var(--vscode-progressBar-background, #0e70c0);
+    border-radius: 3px;
+    transition: width 0.3s ease;
+  }
+
+  .progress-fill.progress-warn {
+    background: var(--vscode-charts-yellow, #cca700);
+  }
+
+  .progress-label {
+    font-size: 0.75em;
     color: var(--vscode-descriptionForeground);
-    margin-bottom: 8px;
+    white-space: nowrap;
   }
+
+  /* Connections toolbar */
+  .conn-toolbar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-3);
+  }
+
+  .conn-filter {
+    flex: 1;
+    max-width: 320px;
+    border-radius: var(--radius);
+  }
+
+  .conn-count {
+    font-size: 0.85em;
+    color: var(--vscode-descriptionForeground);
+    white-space: nowrap;
+  }
+
+  /* Tables */
   .table-wrap {
     overflow-x: auto;
   }
+
   table {
     width: 100%;
     border-collapse: collapse;
     font-size: 0.85em;
   }
+
   th {
     text-align: left;
     padding: 6px 8px;
@@ -453,34 +727,53 @@
     font-weight: 600;
     white-space: nowrap;
   }
+
+  .th-num {
+    text-align: right;
+  }
+
   td {
     padding: 5px 8px;
     border-bottom: 1px solid var(--vscode-widget-border, transparent);
     white-space: nowrap;
   }
+
   tr:hover td {
     background: var(--vscode-list-hoverBackground);
   }
+
   .name-cell {
     max-width: 180px;
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
   .num {
     text-align: right;
     font-variant-numeric: tabular-nums;
   }
-  .empty {
-    padding: 24px;
-    text-align: center;
-    color: var(--vscode-descriptionForeground);
+
+  .tab-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 9px;
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+    font-size: 0.75em;
+    font-weight: 600;
+    margin-left: 4px;
   }
+
   .error-msg {
-    margin: 8px 12px;
-    padding: 8px;
+    margin: var(--space-2) var(--space-3);
+    padding: var(--space-2);
     background: var(--vscode-inputValidation-errorBackground, #5a1d1d);
     border: 1px solid var(--vscode-inputValidation-errorBorder, #be1100);
-    border-radius: 4px;
+    border-radius: var(--radius);
     color: var(--vscode-errorForeground);
   }
 </style>


### PR DESCRIPTION
## Summary

Complete visual overhaul of all webview panels, inspired by Qaze, Kafka UI, and Thunder Client UX patterns.

## New Shared Components

| Component | Purpose |
|-----------|---------|
| `JsonViewer` | Collapsible JSON tree with syntax-highlighted values (strings, numbers, booleans, keys in distinct colors) |
| `CopyButton` | Clipboard copy with green checkmark feedback |
| `StatusBadge` | Colored status pills (success/warning/error/info) |
| `EmptyState` | Consistent loading/empty/error placeholders |
| `KeyValue` | Label-value metadata rows with optional copy |

## Panel Changes

### Message Browser
- Tabbed detail pane: Payload (JsonViewer) | Headers (KeyValue list) | Info (metadata)
- Selected row accent border, message count badges
- Bookmark button in detail toolbar

### Pub/Sub
- Template dropdown (replaces horizontal buttons)
- Subscription pills with colored dots + rate sparkline
- Publish "Sent" feedback animation
- Request timeout presets (1s/5s/10s/30s)
- JsonViewer for request responses

### KV Browser (major redesign)
- Split-pane bucket workspace: searchable key list (left) + value editor (right)
- Browse all keys without leaving the panel
- Inline key creation
- JsonViewer for JSON values
- Collapsible revision history

### Object Viewer
- Card layout with KeyValue metadata rows + CopyButton
- Formatted digest with spacing
- Two-step delete confirmation

### Server Monitor
- Hero section with server name/version/uptime
- Warning badges for slow consumers
- Connection search/filter
- JetStream progress bars (memory/storage vs max)
- Wider sparklines with area fill

## Updated Shared CSS
- Spacing scale (4-32px CSS variables)
- Button variants (small, icon-btn, danger)
- Badge styles, toolbar utility, split-pane layout

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run test` — 51 unit tests pass
- [x] `npm run package` — VSIX builds (150KB)
- [ ] Visual inspection in Extension Development Host (F5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)