### PR TITLE
Fix connection UX, context menus, edge case tests + timestamp releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,10 @@ jobs:
       - name: Create release
         run: |
           SHA_SHORT=$(git rev-parse --short HEAD)
-          TAG="build-${SHA_SHORT}"
+          TIMESTAMP=$(date -u +%Y%m%d-%H%M%S)
+          TAG="build-${TIMESTAMP}-${SHA_SHORT}"
           gh release create "$TAG" leafnode.vsix \
-            --title "Build ${SHA_SHORT}" \
+            --title "Build ${TIMESTAMP} (${SHA_SHORT})" \
             --notes "Automated build from commit ${GITHUB_SHA}" \
             --target "$GITHUB_SHA" \
             --prerelease

--- a/package.json
+++ b/package.json
@@ -104,6 +104,24 @@
         "icon": "$(trash)"
       },
       {
+        "command": "leafnode.connection.viewHealth",
+        "title": "View Health",
+        "category": "Leafnode",
+        "icon": "$(heart)"
+      },
+      {
+        "command": "leafnode.connection.openPubSub",
+        "title": "Open Pub/Sub",
+        "category": "Leafnode",
+        "icon": "$(radio-tower)"
+      },
+      {
+        "command": "leafnode.connection.openMonitor",
+        "title": "Open Server Monitor",
+        "category": "Leafnode",
+        "icon": "$(dashboard)"
+      },
+      {
         "command": "leafnode.importNatsContext",
         "title": "Import NATS CLI Contexts",
         "category": "Leafnode",
@@ -365,6 +383,21 @@
           "command": "leafnode.disconnect",
           "when": "view == leafnode.connections && viewItem == connection:connected",
           "group": "inline"
+        },
+        {
+          "command": "leafnode.connection.viewHealth",
+          "when": "view == leafnode.connections && viewItem == connection:connected",
+          "group": "1_actions"
+        },
+        {
+          "command": "leafnode.connection.openPubSub",
+          "when": "view == leafnode.connections && viewItem == connection:connected",
+          "group": "1_actions"
+        },
+        {
+          "command": "leafnode.connection.openMonitor",
+          "when": "view == leafnode.connections && viewItem == connection:connected",
+          "group": "1_actions"
         },
         {
           "command": "leafnode.editConnection",

--- a/src/connections/manager.ts
+++ b/src/connections/manager.ts
@@ -104,7 +104,8 @@ export class ConnectionManager implements vscode.Disposable {
     const mc = this.connections.get(id);
     if (!mc) return;
     if (mc.nc) {
-      await mc.nc.drain().catch(() => {});
+      await this.forceClose(mc.nc);
+      mc.nc = null;
     }
     this.connections.delete(id);
     await this.persistConnections();
@@ -166,9 +167,23 @@ export class ConnectionManager implements vscode.Disposable {
   async disconnect(id: string): Promise<void> {
     const mc = this.connections.get(id);
     if (!mc?.nc) return;
-    await mc.nc.drain().catch(() => {});
+    const nc = mc.nc;
     mc.nc = null;
     this.setStatus(id, "disconnected");
+    await this.forceClose(nc);
+  }
+
+  private async forceClose(nc: NatsConnection): Promise<void> {
+    try {
+      await Promise.race([
+        nc.drain(),
+        new Promise<void>((_, reject) =>
+          setTimeout(() => reject(new Error("drain timeout")), 3000),
+        ),
+      ]);
+    } catch {
+      await nc.close().catch(() => {});
+    }
   }
 
   private setStatus(id: string, status: ConnectionStatus): void {
@@ -201,10 +216,9 @@ export class ConnectionManager implements vscode.Disposable {
   }
 
   dispose(): void {
-    const drainPromises: Promise<void>[] = [];
     for (const mc of this.connections.values()) {
       if (mc.nc) {
-        drainPromises.push(mc.nc.drain().catch(() => {}));
+        mc.nc.close().catch(() => {});
         mc.nc = null;
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,10 +139,20 @@ export function activate(context: vscode.ExtensionContext): LeafnodeAPI {
   connectionManager.onDidChangeConnectionStatus(updateStatusBar);
   connectionManager.onDidChangeConnections(updateStatusBar);
 
-  // Helper: get first connected connection ID
-  function getActiveConnectionId(): string | undefined {
+  // Helper: get active connection ID — shows picker if multiple connected
+  async function getActiveConnectionId(): Promise<string | undefined> {
     const ids = connectionManager.getConnectedIds();
-    return ids[0];
+    if (ids.length === 0) return undefined;
+    if (ids.length === 1) return ids[0];
+    const configs = connectionManager.getSavedConnections();
+    const pick = await vscode.window.showQuickPick(
+      ids.map((id) => {
+        const c = configs.find((cfg) => cfg.id === id);
+        return { label: c?.name ?? id, description: c?.servers[0], id };
+      }),
+      { placeHolder: "Select connection" },
+    );
+    return pick?.id;
   }
 
   // Commands
@@ -262,6 +272,55 @@ export function activate(context: vscode.ExtensionContext): LeafnodeAPI {
         `Imported ${imported} NATS context${imported !== 1 ? "s" : ""}.`,
       );
     }),
+
+    // Per-connection context menu commands
+    vscode.commands.registerCommand("leafnode.connection.viewHealth",
+      async (item?: ConnectionTreeItem) => {
+        if (!item) return;
+        const rtt = await connectionManager.ping(item.config.id);
+        if (rtt !== undefined) {
+          vscode.window.showInformationMessage(
+            `${item.config.name}: RTT ${rtt}ms — ${item.config.servers[0]}`,
+          );
+        } else {
+          vscode.window.showWarningMessage(
+            `${item.config.name}: Unable to ping (not connected)`,
+          );
+        }
+      },
+    ),
+
+    vscode.commands.registerCommand("leafnode.connection.openPubSub",
+      (item?: ConnectionTreeItem) => {
+        if (!item) return;
+        const connId = item.config.id;
+        const panelId = `pubsub:${connId}`;
+        const panel = panelManager.createOrShow(
+          panelId,
+          `Pub/Sub: ${item.config.name}`,
+          "pub-sub",
+          vscode.ViewColumn.One,
+        );
+        messageRouter.registerPanel(panel, panelId);
+        panel.webview.postMessage({ type: "init", connectionId: connId });
+      },
+    ),
+
+    vscode.commands.registerCommand("leafnode.connection.openMonitor",
+      (item?: ConnectionTreeItem) => {
+        if (!item) return;
+        const connId = item.config.id;
+        const panelId = `monitor:${connId}`;
+        const panel = panelManager.createOrShow(
+          panelId,
+          `Monitor: ${item.config.name}`,
+          "server-monitor",
+          vscode.ViewColumn.One,
+        );
+        messageRouter.registerPanel(panel, panelId);
+        panel.webview.postMessage({ type: "init", connectionId: connId });
+      },
+    ),
 
     // Export connections
     vscode.commands.registerCommand("leafnode.exportConnections", async () => {
@@ -416,7 +475,7 @@ export function activate(context: vscode.ExtensionContext): LeafnodeAPI {
 
     // Stream CRUD commands
     vscode.commands.registerCommand("leafnode.streams.create", async () => {
-      const connId = getActiveConnectionId();
+      const connId = await getActiveConnectionId();
       if (!connId) {
         vscode.window.showWarningMessage("Connect to a NATS server first.");
         return;
@@ -682,8 +741,8 @@ export function activate(context: vscode.ExtensionContext): LeafnodeAPI {
     ),
 
     // Pub/Sub command
-    vscode.commands.registerCommand("leafnode.openPubSub", () => {
-      const connId = getActiveConnectionId();
+    vscode.commands.registerCommand("leafnode.openPubSub", async () => {
+      const connId = await getActiveConnectionId();
       if (!connId) {
         vscode.window.showWarningMessage("Connect to a NATS server first.");
         return;
@@ -747,7 +806,7 @@ export function activate(context: vscode.ExtensionContext): LeafnodeAPI {
     ),
 
     vscode.commands.registerCommand("leafnode.kv.createBucket", async () => {
-      const connId = getActiveConnectionId();
+      const connId = await getActiveConnectionId();
       if (!connId) {
         vscode.window.showWarningMessage("Connect to a NATS server first.");
         return;
@@ -812,7 +871,7 @@ export function activate(context: vscode.ExtensionContext): LeafnodeAPI {
 
     vscode.commands.registerCommand("leafnode.kv.createKey",
       async (item?: { connectionId: string; bucket: string }) => {
-        const connId = item?.connectionId ?? getActiveConnectionId();
+        const connId = item?.connectionId ?? await getActiveConnectionId();
         const bucketName = item?.bucket;
         if (!connId) {
           vscode.window.showWarningMessage("Connect to a NATS server first.");
@@ -933,8 +992,8 @@ export function activate(context: vscode.ExtensionContext): LeafnodeAPI {
     }),
 
     // Server Monitor command
-    vscode.commands.registerCommand("leafnode.openServerMonitor", () => {
-      const connId = getActiveConnectionId();
+    vscode.commands.registerCommand("leafnode.openServerMonitor", async () => {
+      const connId = await getActiveConnectionId();
       if (!connId) {
         vscode.window.showWarningMessage("Connect to a NATS server first.");
         return;

--- a/src/test/e2e/extension.test.ts
+++ b/src/test/e2e/extension.test.ts
@@ -1786,4 +1786,102 @@ suite("Leafnode Extension E2E", () => {
       await svc.jetstream.deleteStream(stream);
     });
   });
+
+  // ─── Edge Cases ───────────────────────────────────────────
+
+  suite("Edge Cases", () => {
+    const connId = uniqueName("edge_conn");
+
+    suiteSetup(async function () {
+      this.timeout(10000);
+      await api.connectionManager.addConnection({
+        id: connId, name: "Edge Tests", servers: [NATS_URL],
+        auth: { type: "anonymous" },
+      });
+    });
+
+    suiteTeardown(async () => {
+      try { await api.connectionManager.disconnect(connId); } catch { /* ok */ }
+      try { await api.connectionManager.removeConnection(connId); } catch { /* ok */ }
+    });
+
+    test("double disconnect is idempotent", async function () {
+      this.timeout(10000);
+      await api.connectionManager.connect(connId);
+      await api.connectionManager.disconnect(connId);
+      // Second disconnect should not throw
+      await api.connectionManager.disconnect(connId);
+      assert.strictEqual(api.connectionManager.getStatus(connId), "disconnected");
+    });
+
+    test("connect to already-connected is idempotent", async function () {
+      this.timeout(10000);
+      await api.connectionManager.connect(connId);
+      // Second connect should return without error
+      await api.connectionManager.connect(connId);
+      assert.strictEqual(api.connectionManager.getStatus(connId), "connected");
+      await api.connectionManager.disconnect(connId);
+    });
+
+    test("getServices returns undefined after disconnect", async function () {
+      this.timeout(10000);
+      await api.connectionManager.connect(connId);
+      assert.ok(api.getServices(connId), "Should have services when connected");
+      await api.connectionManager.disconnect(connId);
+      assert.strictEqual(api.getServices(connId), undefined, "Should be undefined after disconnect");
+    });
+
+    test("disconnect then reconnect works", async function () {
+      this.timeout(10000);
+      await api.connectionManager.connect(connId);
+      await api.connectionManager.disconnect(connId);
+      await api.connectionManager.connect(connId);
+      assert.strictEqual(api.connectionManager.getStatus(connId), "connected");
+      const svc = api.getServices(connId);
+      assert.ok(svc, "Services should be available after reconnect");
+      await api.connectionManager.disconnect(connId);
+    });
+
+    test("rapid connect-disconnect cycle", async function () {
+      this.timeout(15000);
+      for (let i = 0; i < 3; i++) {
+        await api.connectionManager.connect(connId);
+        assert.strictEqual(api.connectionManager.getStatus(connId), "connected");
+        await api.connectionManager.disconnect(connId);
+        assert.strictEqual(api.connectionManager.getStatus(connId), "disconnected");
+      }
+    });
+
+    test("remove connection while connected", async function () {
+      this.timeout(10000);
+      const tempId = uniqueName("temp");
+      await api.connectionManager.addConnection({
+        id: tempId, name: "Temp", servers: [NATS_URL],
+        auth: { type: "anonymous" },
+      });
+      await api.connectionManager.connect(tempId);
+      assert.strictEqual(api.connectionManager.getStatus(tempId), "connected");
+      // Remove should disconnect and remove
+      await api.connectionManager.removeConnection(tempId);
+      const saved = api.connectionManager.getSavedConnections();
+      assert.ok(!saved.some((c) => c.id === tempId), "Should be removed");
+    });
+
+    test("operations after disconnect return gracefully", async function () {
+      this.timeout(10000);
+      await api.connectionManager.connect(connId);
+      assert.ok(api.getServices(connId), "Services available before disconnect");
+      await api.connectionManager.disconnect(connId);
+      // getServices should return undefined for disconnected
+      const newSvc = api.getServices(connId);
+      assert.strictEqual(newSvc, undefined);
+    });
+
+    test("per-connection context commands exist", async () => {
+      const all = await vscode.commands.getCommands(true);
+      assert.ok(all.includes("leafnode.connection.viewHealth"));
+      assert.ok(all.includes("leafnode.connection.openPubSub"));
+      assert.ok(all.includes("leafnode.connection.openMonitor"));
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes critical connection UX issues, adds per-connection context menus, expands edge case test coverage, and timestamps release tags.

## Connection UX Fixes

- **Disconnect no longer hangs** — status updates immediately, drain has 3s timeout with force-close fallback via `nc.close()`
- **Multi-connection picker** — `getActiveConnectionId()` shows quick-pick when 2+ servers connected instead of silently using the first one
- **Per-connection context menu** — right-click a connected server shows:
  - View Health (ping + RTT notification)
  - Open Pub/Sub (for that specific connection)
  - Open Server Monitor (for that specific connection)

## Release Tag Fix

Tags now use `build-YYYYMMDD-HHMMSS-<sha>` format so newer builds sort above older ones in the releases list.

## Edge Case Tests (8 new)

- Double disconnect is idempotent
- Connect to already-connected is idempotent
- getServices returns undefined after disconnect
- Disconnect then reconnect works
- Rapid connect-disconnect cycle (3 iterations)
- Remove connection while connected
- Operations after disconnect return gracefully
- Per-connection context commands registered

**Total: 101 E2E + 51 unit = 152 tests**

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run build` succeeds
- [ ] `npm run test` — 51 unit tests pass
- [ ] `npm run test:e2e` — 101 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)